### PR TITLE
Feat/3/screen routing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:stockapp/routes/TabView.dart';
+import 'package:stockapp/screens/login_screen.dart';
 import 'screens/main_screen.dart';
 
 void main() {
@@ -15,7 +17,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const MainScreen(),  // MainScreen 호출
+      home: const LoginScreen(),  // MainScreen 호출
     );
   }
 }

--- a/lib/routes/TabView.dart
+++ b/lib/routes/TabView.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/screens/chart_screen.dart';
+import 'package:stockapp/screens/diary_screen.dart';
+import 'package:stockapp/screens/interest_screen.dart';
+import 'package:stockapp/screens/main_screen.dart';
+import 'package:stockapp/screens/mypage_screen.dart';
+
+class Tabview extends StatefulWidget {
+  const Tabview({super.key});
+
+  @override
+  State<Tabview> createState() => _TabviewState();
+}
+
+class _TabviewState extends State<Tabview> {
+  var _index = 0;
+
+  List<Widget> _pages = [
+    MainScreen(),
+    InterestScreen(),
+    ChartScreen(),
+    DairyScreen(),
+    MypageScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_index], // 현재 선택된 화면을 여기에 렌더링
+      bottomNavigationBar: SizedBox(
+        height: 70,
+        child: BottomNavigationBar(
+          currentIndex: _index,
+          backgroundColor: Colors.white,
+          // 또는 원하는 배경색
+          selectedItemColor: Colors.black,
+          // 선택된 아이템 색상
+          unselectedItemColor: Color(0xFFB3B3B3),
+          // 선택되지 않은 아이템 색상
+          selectedLabelStyle: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.normal,
+          ),
+          // 선택된 라벨 스타일
+          unselectedLabelStyle: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.normal,
+          ),
+          showUnselectedLabels: true,
+          type: BottomNavigationBarType.fixed,
+          onTap: (value) {
+            setState(() {
+              _index = value;
+            });
+          },
+          items: [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.home_rounded, size: 29),
+              label: '홈',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.favorite_rounded, size: 29),
+              label: '관심종목',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.show_chart_outlined, size: 29),
+              label: '패턴',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.sentiment_satisfied_alt, size: 29),
+              label: '감정일기',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person, size: 32),
+              label: 'My',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/diary_screen.dart
+++ b/lib/screens/diary_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class DairyScreen extends StatelessWidget {
+  const DairyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dairy Screen'),
+      ),
+      body: const Center(
+        child: Text('감정일기 페이지'),
+      ),
+    );
+  }
+}

--- a/lib/screens/interest_screen.dart
+++ b/lib/screens/interest_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class InterestScreen extends StatelessWidget {
+  const InterestScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Interest Screen'),
+      ),
+      body: const Center(
+        child: Text('관심종목 페이지'),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/routes/TabView.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  void _handleLogin(BuildContext context) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => const Tabview()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('로그인')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => _handleLogin(context),
+          child: const Text('로그인'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -6,11 +6,8 @@ class MainScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Main Screen'),
-      ),
       body: const Center(
-        child: Text('Welcome to the main screen!'),
+        child: Text('메인페이지'),
       ),
     );
   }

--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class MypageScreen extends StatelessWidget {
+  const MypageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mypage Screen'),
+      ),
+      body: const Center(
+        child: Text('마이페이지'),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -139,6 +147,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: "direct dev"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +280,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.7.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  path_provider: ^2.1.2
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
네비게이션바 이동 및 차트 페이지 이름 변경

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #3 

## ⏳ 작업 내용
- 네비게이션바 추가
- (화면간 이동 구현) : Main.dart에서 LoginScreen 호출 후 Pageroute를 통해 로그인 버튼 클릭시 TabView.dart로 이동 후 하단 탭을 누르면 해당 인덱스 번호가 _index에 저장되고, 그 번호에 맞는 화면을 _pages[_index]에서 꺼내서 보여주면서 화면 이동하도록 구현

## 📸 스크린샷
![제목 없음](https://github.com/user-attachments/assets/22fd47ce-3f14-44bb-b155-7ceae5d18d27)


## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 차트페이지 이름을 chart.dart에서 chart_screen.dart로 수정했습니다! 작업 시 유의해서 확인해주세요!