### PR TITLE
Feat/#11 stock detail screen

### DIFF
--- a/lib/data/candle_api.dart
+++ b/lib/data/candle_api.dart
@@ -1,0 +1,32 @@
+import 'package:interactive_chart/interactive_chart.dart';
+
+class MockDataTesla {
+  static const List<dynamic> _rawData = [
+    // (Price data for Tesla Inc, taken from Yahoo Finance)
+    // timestamp, open, high, low, close, volume
+    // 시간, 시가, 고가, 저가, 종가, 거래량
+    [1633354200, 51000, 51500, 50500, 51200, 850000],
+    [1633440600, 51400, 52000, 50800, 51600, 18432600],
+    [1633527000, 51200, 51900, 51000, 51550, 14632800],
+    [1633613400, 51800, 53200, 51700, 52800, 19195800],
+    [1633699800, 52800, 52850, 51800, 52200, 16711100],
+    [1633959000, 52100, 53000, 52000, 52600, 14175800],
+    [1634064472, 52900, 53600, 52500, 53450, 17289281],
+    [1634150872, 53500, 54000, 53000, 53800, 16500000],
+    [1634237272, 53800, 55000, 53600, 54800, 17800000],
+    [1634323672, 54800, 55500, 54500, 55300, 18200000],
+    [1634410072, 55300, 55800, 55000, 55100, 16000000],
+    [1634496472, 55100, 55600, 54900, 55550, 17500000],
+  ];
+
+  static List<CandleData> get candles => _rawData
+      .map((row) => CandleData(
+    timestamp: row[0] * 1000, //timestamp 초단위 * 1000 = 밀리초
+    open: row[1]?.toDouble(),
+    high: row[2]?.toDouble(),
+    low: row[3]?.toDouble(),
+    close: row[4]?.toDouble(),
+    volume: row[5]?.toDouble(),
+  ))
+      .toList();
+}

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,14 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:stockapp/screens/stock_detail_screen.dart';
 
 class MainScreen extends StatelessWidget {
   const MainScreen({super.key});
 
+  void _handleDetail(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const DetailScreen()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: const Center(
-        child: Text('메인페이지'),
-      ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('메인페이지'),
+              ElevatedButton(
+                  onPressed: () => _handleDetail(context),
+                  child: const Text('종목 상세 페이지')
+              ),
+            ],
+          ),
+        )
     );
   }
 }

--- a/lib/screens/stock_detail_screen.dart
+++ b/lib/screens/stock_detail_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/widgets/stock_details/StockChart.dart';
+import 'package:stockapp/widgets/stock_details/stockDetail.dart';
+import 'package:stockapp/widgets/stock_details/stockName.dart';
+
+class DetailScreen extends StatelessWidget {
+  const DetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: Column(
+        children: [
+          StockName(),
+          Expanded(child: CandlestickChart()),
+          Expanded(child: StockDetail()),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/common/InfoCardGroup.dart
+++ b/lib/widgets/common/InfoCardGroup.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+class InfoCardGroup extends StatelessWidget {
+  final String title;
+  final List<Map<String, dynamic>> rows; // 변경된 타입
+
+  const InfoCardGroup({
+    super.key,
+    required this.title,
+    required this.rows,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: CardStyles.title),
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(8),
+                boxShadow: [
+                  BoxShadow(color: Color(0xFFAEAEAE), blurRadius: 3),
+                ],
+              ),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final double itemWidth = (constraints.maxWidth - 40) / 3;
+                  return Wrap(
+                    spacing: 20,
+                    runSpacing: 12,
+                    children: rows.map((row) {
+                      final label = row['label'] as String;
+                      final value = row['value'] as String;
+                      final color = row['color'] as Color? ?? Colors.black; // 기본값 검정
+
+                      return SizedBox(
+                        width: itemWidth,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Text(label, style: CardStyles.subtitle),
+                            const SizedBox(height: 4),
+                            Text(
+                              value,
+                              style: CardStyles.cost.copyWith(color: color),
+                            ),
+                          ],
+                        ),
+                      );
+                    }).toList(),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// styles
+class CardStyles {
+  static const TextStyle title = TextStyle(
+    fontWeight: FontWeight.bold,
+    fontSize: 16,
+    color: Color(0xFF03314B),
+  );
+
+  static const TextStyle subtitle = TextStyle(
+      color: Color(0xFF8198A5),
+      fontSize: 12
+  );
+
+  static const TextStyle cost = TextStyle(
+    fontWeight: FontWeight.bold,
+    fontSize: 16,
+  );
+}

--- a/lib/widgets/common/TopTabSelector.dart
+++ b/lib/widgets/common/TopTabSelector.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class TopTabSelector extends StatelessWidget {
+  final List<String> tabs;
+  final int selectedIndex;
+  final Function(int) onTap;
+
+  const TopTabSelector({
+    super.key,
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: List.generate(tabs.length, (index) {
+          final isSelected = index == selectedIndex;
+          return SizedBox(
+            width: 80,
+            child: GestureDetector(
+              onTap: () => onTap(index),
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: isSelected ? Colors.black : Colors.grey[300]!,
+                      width: 1.5,
+                    ),
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  tabs[index],
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.normal,
+                    color: isSelected ? Colors.black : Colors.grey,
+                  ),
+                ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+// styles

--- a/lib/widgets/stock_details/StockChart.dart
+++ b/lib/widgets/stock_details/StockChart.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:interactive_chart/interactive_chart.dart';
+
+import '../../data/candle_api.dart';
+
+class CandlestickChart extends StatefulWidget {
+  const CandlestickChart({super.key});
+
+  @override
+  State<CandlestickChart> createState() => _CandlestickChartState();
+}
+
+class _CandlestickChartState extends State<CandlestickChart> {
+  final List<CandleData> _data = MockDataTesla.candles;
+  bool _showAverage = false; // 이동 평균선
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+          child: SafeArea(
+            minimum: const EdgeInsets.all(24.0),
+            child: InteractiveChart(
+              candles: _data, //데이터
+              // 차트 스타일
+              style: ChartStyle(
+                priceGainColor: Color(0xFFDF1525),   // 상승 → 빨강
+                priceLossColor: Color(0xFF1573FE),
+              //   volumeColor: Colors.teal.withOpacity(0.8),
+              //   trendLineStyles: [
+              //     Paint()
+              //       ..strokeWidth = 2.0
+              //       ..strokeCap = StrokeCap.round
+              //       ..color = Colors.deepOrange,
+              //     Paint()
+              //       ..strokeWidth = 4.0
+              //       ..strokeCap = StrokeCap.round
+              //       ..color = Colors.orange,
+              //   ],
+              //   priceGridLineColor: Colors.blue[200]!,
+              //   priceLabelStyle: TextStyle(color: Colors.blue[200]),
+              //   timeLabelStyle: TextStyle(color: Colors.blue[200]),
+              //   selectionHighlightColor: Colors.red.withOpacity(0.2),
+                overlayBackgroundColor: Colors.black.withOpacity(0.6),
+              //   overlayTextStyle: TextStyle(color: Colors.red[100]),
+                // timeLabelHeight: 32,
+              //   volumeHeightFactor: 0.2, // volume area is 20% of total height
+              ),
+              /** Customize axis labels */
+              // timeLabel: (timestamp, visibleDataCount) => "📅",
+              priceLabel: (price) => "${price.round()}",
+              /** Customize overlay (tap and hold to see it)
+               ** Or return an empty object to disable overlay info. */
+              // 시간, 시가, 고가, 저가, 종가, 거래량 -> 한글로 변경
+              overlayInfo: (candle) {
+                final date = DateTime.fromMillisecondsSinceEpoch(candle.timestamp);
+                final formattedDate = "${date.year}-${date.month}-${date.day}";
+                final volumeMillion = (candle.volume ?? 0) / 1000000;
+
+                return {
+                  "날짜": formattedDate,
+                  "시가": "${candle.open?.toStringAsFixed(2)}",
+                  "고가": "${candle.high?.toStringAsFixed(2)}",
+                  "저가": "${candle.low?.toStringAsFixed(2)}",
+                  "종가": "${candle.close?.toStringAsFixed(2)}",
+                  "거래량": "${volumeMillion.toStringAsFixed(3)}M",  // 예: 17.500M
+                };
+              },
+              /** Callbacks */
+              // onTap: (candle) => print("user tapped on $candle"),
+              // onCandleResize: (width) => print("each candle is $width wide"),
+            ),
+          ),
+        );
+  }
+
+// 이동 평균선
+  _computeTrendLines() {
+    final ma7 = CandleData.computeMA(_data, 7);
+    final ma30 = CandleData.computeMA(_data, 30);
+    final ma90 = CandleData.computeMA(_data, 90);
+
+    for (int i = 0; i < _data.length; i++) {
+      _data[i].trends = [ma7[i], ma30[i], ma90[i]];
+    }
+  }
+
+  _removeTrendLines() {
+    for (final data in _data) {
+      data.trends = [];
+    }
+  }
+}

--- a/lib/widgets/stock_details/stockDetail.dart
+++ b/lib/widgets/stock_details/stockDetail.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/widgets/common/TopTabSelector.dart';
+import 'package:stockapp/widgets/common/InfoCardGroup.dart';
+
+
+class StockDetail extends StatefulWidget {
+  const StockDetail({super.key});
+
+  @override
+  State<StockDetail> createState() => _StockDetailScreenState();
+}
+
+class _StockDetailScreenState extends State<StockDetail> {
+  int _selectedTabIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TopTabSelector(
+          tabs: const ['AI 예측', '재무정보'],
+          selectedIndex: _selectedTabIndex,
+          onTap: (index) {
+            setState(() {
+              _selectedTabIndex = index;
+            });
+          },
+        ),
+        Expanded(
+          child: _selectedTabIndex == 0
+              ? const AIPredictionView()
+              : const FinancialInfoView(),
+        ),
+      ],
+    );
+  }
+}
+
+// AI 예측 탭 내용
+class AIPredictionView extends StatelessWidget {
+  const AIPredictionView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return InfoCardGroup(
+      title: 'AI 예측 주가',
+      rows: const [
+        {'label': '현재가', 'value': '54,300', 'color': Color(0xFFF99F01)},
+        {'label': '상한 예측가', 'value': '63,000', 'color': Color(0xFFEC221F)},
+        {'label': '하한 예측가', 'value': '53,100', 'color': Color(0xFF289BF6)},
+        {'label': '적정 매도 가격', 'value': '62,500'},
+        {'label': '적정 매수 가격', 'value': '52,900'},
+        {'label': '예측 범위', 'value': '20일 이내'},
+      ],
+    );
+  }
+}
+
+// 재무정보 탭 내용
+class FinancialInfoView extends StatelessWidget {
+  const FinancialInfoView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return InfoCardGroup(
+      title: '재무 정보',
+      rows: const [
+        {'label': '시가총액', 'value': '372.1조원'},
+        {'label': '배당수익률', 'value': '2.56%'},
+        {'label': 'ROE', 'value': '9.0%'},
+        {'label': 'PBR', 'value': '1.0배'},
+        {'label': 'PER', 'value': '11.3배'},
+        {'label': 'PSR', 'value': '1.3배'},
+
+      ],
+    );
+  }
+}
+

--- a/lib/widgets/stock_details/stockName.dart
+++ b/lib/widgets/stock_details/stockName.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+// StockName
+class StockName extends StatefulWidget {
+  const StockName({super.key});
+
+  @override
+  State<StockName> createState() => _StockNameState();
+}
+
+class _StockNameState extends State<StockName> {
+  bool isFavorite = false; // 초기 상태: 빈 하트
+
+  @override
+  Widget build(BuildContext context) {
+    // 실제 데이터(하드코딩 -> API)
+    final int changeAmount = 600;
+    final double changeRate = 1.12;
+    // 등락률,금액 출력 컬러
+    final bool isRising = changeAmount >= 0;
+    final Color changeColor = isRising ? Color(0xFFDF1525) : Color(0xFF1573FE);
+    // 부호
+    final String sign = isRising ? '+' : '';
+    final String changeText =
+        '$sign${changeAmount.abs()}(${changeRate.abs().toStringAsFixed(2)}%)';
+
+    return Padding(
+        padding: const EdgeInsets.only(left: 28, right: 15),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('삼성전자', style: AppStyles.title),
+                Text('54,300', style: AppStyles.cost),
+                Text(changeText,
+                  style: AppStyles.profit.copyWith(color: changeColor),
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: IconButton(
+                onPressed: () {
+                  setState(() {
+                    isFavorite = !isFavorite; // 상태 토글
+                  });
+                },
+                icon: Icon(
+                  isFavorite
+                      ? Icons.favorite      // 채운 하트
+                      : Icons.favorite_outline, // 빈 하트
+                  size: 45,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+          ],
+        ),
+    );
+  }
+}
+
+// styles
+class AppStyles {
+  static const TextStyle title = TextStyle(
+    fontWeight: FontWeight.bold,
+    fontSize: 20,
+  );
+
+  static const TextStyle cost = TextStyle(
+    fontWeight: FontWeight.bold,
+    fontSize: 36,
+  );
+
+  static const TextStyle profit = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 16,
+    color: Colors.red,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,6 +83,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  interactive_chart:
+    dependency: "direct main"
+    description:
+      name: interactive_chart
+      sha256: "6237d938e57205034b6f3e96158954d876bf86467d76495d93ef393c883753b8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   path_provider: ^2.1.2
+  interactive_chart: ^0.3.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
종목 상세 화면 구현

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #11 

## ⏳ 작업 내용
- 종목 상세 정보 UI 추가
- 종목 차트 추가
- 관심 종목 설정 기능 추가
- AI 예측 주가 컴포넌트 추가
- 재무 정보 컴포넌트 추가

## 📸 스크린샷
<img width="365" alt="image" src="https://github.com/user-attachments/assets/1c67bb7a-3284-4f2b-ad88-e461bf886009" />

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 공통 UI 요소로 활용 가능한 InfoCardGroup과 TopTabSelector 위젯을 widgets/common 디렉토리에 추가했습니다. 필요 시 자유롭게 호출하여 사용하시면 됩니다!