### PR TITLE
[Feat] 관심 종목 페이지 구현 + api 연동

### DIFF
--- a/lib/data/interest_pattern_api.dart
+++ b/lib/data/interest_pattern_api.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+import '../models/pattern_apply.dart';
+
+class PatternApi {
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://pattern-catcher.net:8080',
+      // ★ 4xx도 응답은 받게 하고 우리가 직접 분기
+      validateStatus: (s) => s != null && s >= 200 && s < 500,
+      connectTimeout: const Duration(seconds: 8),
+      receiveTimeout: const Duration(seconds: 8),
+    ),
+  );
+
+  /// 패턴이 없으면 null 반환
+  Future<PatternApply?> fetchPatternApply(int stockId) async {
+    try {
+      final res = await _dio.get('/pattern-applies/stocks/$stockId');
+
+      // 404 => 패턴 없음
+      if (res.statusCode == 404) return null;
+
+      if (res.data is Map<String, dynamic>) {
+        final data = res.data as Map<String, dynamic>;
+
+        // 성공
+        if (data['isSuccess'] == true) {
+          return PatternApply.fromJson(data);
+        }
+
+        // 서버가 200으로 내려도 isSuccess=false + code로 구분
+        final code = data['code']?.toString() ?? '';
+        if (code == 'PATTERN_APPLY404') {
+          return null; // 패턴 없음
+        }
+
+        // 그 외는 진짜 에러
+        throw Exception(data['message'] ?? '패턴 조회 실패');
+      }
+
+      throw Exception('예상치 못한 응답 형식');
+    } on DioException catch (e) {
+      // 네트워크/타임아웃 등은 에러
+      if (e.response?.statusCode == 404) return null; // 혹시 여기로 온 404도 처리
+      rethrow;
+    }
+  }
+}

--- a/lib/data/interestlist_api.dart
+++ b/lib/data/interestlist_api.dart
@@ -1,0 +1,30 @@
+// lib/data/watchlist_api.dart
+import 'package:dio/dio.dart';
+import '../models/stock_brief.dart';
+
+class InterestlistApi {
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://pattern-catcher.net:8080',
+      connectTimeout: const Duration(seconds: 8),
+      receiveTimeout: const Duration(seconds: 8),
+      headers: {'Content-Type': 'application/json'},
+    ),
+  );
+
+  Future<List<StockBrief>> fetchWatchlist() async {
+    final res = await _dio.get('/watchlist');
+
+    if (res.statusCode == 200 && res.data is Map<String, dynamic>) {
+      final map = res.data as Map<String, dynamic>;
+      if (map['isSuccess'] == true && map['result'] is List) {
+        final list = (map['result'] as List)
+            .map((e) => StockBrief.fromJson(e as Map<String, dynamic>))
+            .toList();
+        return list;
+      }
+      throw Exception('API 실패: ${map['message'] ?? 'Unknown'}');
+    }
+    throw Exception('HTTP ${res.statusCode}');
+  }
+}

--- a/lib/data/recent_api.dart
+++ b/lib/data/recent_api.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart';
+import '../models/stock_brief.dart';
+
+class RecentApi {
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://pattern-catcher.net:8080',
+      connectTimeout: const Duration(seconds: 8),
+      receiveTimeout: const Duration(seconds: 8),
+      headers: {'Content-Type': 'application/json'},
+    ),
+  );
+
+  Future<List<StockBrief>> fetchRecent() async {
+    final res = await _dio.get('/stocks/recent');
+
+    if (res.statusCode == 200 &&
+        res.data is Map<String, dynamic> &&
+        res.data['isSuccess'] == true &&
+        res.data['result'] is List) {
+      final list = (res.data['result'] as List)
+          .map((e) => StockBrief.fromJson(e as Map<String, dynamic>))
+          .toList();
+      return list;
+    }
+    throw Exception('최근 목록 불러오기 실패: ${res.statusCode} ${res.data}');
+  }
+}

--- a/lib/models/pattern_apply.dart
+++ b/lib/models/pattern_apply.dart
@@ -1,0 +1,94 @@
+class PatternApply {
+  final int stockId;
+  final String stockName;
+  final String stockImage;
+  final PatternInfo? pattern;
+  final BacktestResult? backtest;
+
+  PatternApply({
+    required this.stockId,
+    required this.stockName,
+    required this.stockImage,
+    required this.pattern,
+    required this.backtest,
+  });
+
+  factory PatternApply.fromJson(Map<String, dynamic> json) {
+    final r = json['result'] as Map<String, dynamic>;
+    final stock = r['stock'] as Map<String, dynamic>;
+    final patt = r['pattern'] as Map<String, dynamic>?;
+    final bt   = r['backtestResult'] as Map<String, dynamic>?;
+
+    return PatternApply(
+      stockId: stock['stockId'] as int,
+      stockName: stock['stockName'] as String,
+      stockImage: stock['stockImage'] as String? ?? '',
+      pattern: patt == null ? null : PatternInfo.fromJson(patt),
+      backtest: bt == null ? null : BacktestResult.fromJson(bt),
+    );
+  }
+
+  bool get hasPattern  => pattern  != null && pattern!.points.isNotEmpty;
+  bool get hasBacktest => backtest != null;
+}
+
+class PatternInfo {
+  final int patternId;
+  final List<num> points;
+  final double tolerance;
+  final String periodValue;
+  final String periodUnit;
+
+  PatternInfo({
+    required this.patternId,
+    required this.points,
+    required this.tolerance,
+    required this.periodValue,
+    required this.periodUnit,
+  });
+
+  factory PatternInfo.fromJson(Map<String, dynamic> json) => PatternInfo(
+    patternId: json['patternId'] as int,
+    points: (json['points'] as List).map((e) => e as num).toList(),
+    tolerance: (json['tolerance'] as num).toDouble(),
+    periodValue: json['periodValue'].toString(),
+    periodUnit: json['periodUnit'].toString(),
+  );
+}
+
+// ★ 백테스트 결과 모델 추가
+class BacktestResult {
+  final int backtestId;
+  final String executedAt;   // '2025-08-16'
+  final String startDate;    // '2025-07-01'
+  final String endDate;      // '2025-08-13'
+  final int matchedCount;    // 5
+  final num winRate;         // 20  (단위: %)
+  final double averageReturn; // 0.05342... (단위: 비율)
+  final double maxReturn;     // 1.92 (단위: % 인지 리턴값 인지 백엔드 정의에 따름)
+  final String maxReturnDate; // '2025-07-14'
+
+  BacktestResult({
+    required this.backtestId,
+    required this.executedAt,
+    required this.startDate,
+    required this.endDate,
+    required this.matchedCount,
+    required this.winRate,
+    required this.averageReturn,
+    required this.maxReturn,
+    required this.maxReturnDate,
+  });
+
+  factory BacktestResult.fromJson(Map<String, dynamic> json) => BacktestResult(
+    backtestId: json['backtestId'] as int,
+    executedAt: json['executedAt'] as String,
+    startDate: json['startDate'] as String,
+    endDate: json['endDate'] as String,
+    matchedCount: json['matchedCount'] as int,
+    winRate: json['winRate'] as num,
+    averageReturn: (json['averageReturn'] as num).toDouble(),
+    maxReturn: (json['maxReturn'] as num).toDouble(),
+    maxReturnDate: json['maxReturnDate'] as String,
+  );
+}

--- a/lib/models/stock_brief.dart
+++ b/lib/models/stock_brief.dart
@@ -1,0 +1,21 @@
+// lib/models/stock_brief.dart
+class StockBrief {
+  final int id;
+  final String name;
+  final String symbol;
+  final String imageUrl;
+
+  StockBrief({
+    required this.id,
+    required this.name,
+    required this.symbol,
+    required this.imageUrl,
+  });
+
+  factory StockBrief.fromJson(Map<String, dynamic> json) => StockBrief(
+    id: json['stockId'] as int,
+    name: json['stockName'] as String,
+    symbol: json['stockSymbol'] as String,
+    imageUrl: json['imageUrl'] as String? ?? '',
+  );
+}

--- a/lib/screens/interest_pattern_screen.dart
+++ b/lib/screens/interest_pattern_screen.dart
@@ -1,10 +1,87 @@
+// lib/screens/interest/interest_pattern_screen.dart
 import 'package:flutter/material.dart';
+import 'package:stockapp/data/interest_pattern_api.dart';
+import 'package:stockapp/models/pattern_apply.dart';
+import 'package:stockapp/widgets/interest/pattern_empty_view.dart';
+import 'package:stockapp/widgets/interest/pattern_exists_view.dart';
+import 'package:stockapp/widgets/interest/pattern_stock_header.dart';
 
-class InterestPatternScreen extends StatelessWidget {
-  const InterestPatternScreen({super.key});
+class InterestPatternScreen extends StatefulWidget {
+  final int stockId;
+  final String? stockName;
+
+  const InterestPatternScreen({super.key, required this.stockId, this.stockName});
+
+  @override
+  State<InterestPatternScreen> createState() => _InterestPatternScreenState();
+}
+
+class _InterestPatternScreenState extends State<InterestPatternScreen> {
+  final _api = PatternApi();
+  late Future<PatternApply?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _api.fetchPatternApply(widget.stockId);
+  }
+
+  Future<void> _reload() async {
+    setState(() => _future = _api.fetchPatternApply(widget.stockId));
+    await _future;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return const Text('InterestPatternScreen');
+    return FutureBuilder<PatternApply?>(
+      future: _future,
+      builder: (context, snap) {
+        if (snap.connectionState == ConnectionState.waiting) {
+          return const Scaffold(body: Center(child: CircularProgressIndicator()));
+        }
+        if (snap.hasError) {
+          return Scaffold(
+            appBar: AppBar(title: Text(widget.stockName ?? '패턴')),
+            body: Center(
+              child: TextButton.icon(
+                onPressed: _reload,
+                icon: const Icon(Icons.refresh),
+                label: Text('불러오기 실패: ${snap.error}'),
+              ),
+            ),
+          );
+        }
+
+        final data = snap.data; // null = 패턴 없음
+        final title = data != null && data.stockName.isNotEmpty
+            ? data.stockName
+            : (widget.stockName ?? '패턴');
+        final img = (data != null && data.stockImage.isNotEmpty) ? data.stockImage : null;
+        final hasPattern = data != null && data.hasPattern;
+
+        return Scaffold(
+          appBar: AppBar(),
+          backgroundColor: Colors.white,
+          body: RefreshIndicator(
+            onRefresh: _reload,
+            child: Column(
+              children: [
+                StockHeader(name: title, imageUrl: img),
+                Expanded(
+                  child: hasPattern
+                      ? PatternExistsView(
+                    data: data!,
+                    onDelete: () {/* TODO */},
+                    onEdit: () {/* TODO */},
+                    onRunBacktest: () {/* TODO */},
+                  )
+                      : const PatternEmptyView(),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/screens/interest_pattern_screen.dart
+++ b/lib/screens/interest_pattern_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class InterestPatternScreen extends StatelessWidget {
+  const InterestPatternScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text('InterestPatternScreen');
+  }
+}

--- a/lib/screens/interest_screen.dart
+++ b/lib/screens/interest_screen.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/data/watchlist_api.dart';
 import 'package:stockapp/models/StockItemModel.dart';
-import 'package:stockapp/widgets/main/StockItems.dart';
-import 'stock_detail_screen.dart';
+import 'package:stockapp/widgets/interest/WatchlistAppBarActions.dart';
 
 class InterestScreen extends StatefulWidget {
   const InterestScreen({super.key});
@@ -13,7 +12,7 @@ class InterestScreen extends StatefulWidget {
 
 class _InterestScreenState extends State<InterestScreen> {
   final WatchlistApiService _apiService = WatchlistApiService();
-  // 관심종목 목록을 불러오는 Future
+
   late Future<List<StockItem>> _watchlistFuture;
 
   @override
@@ -36,61 +35,24 @@ class _InterestScreenState extends State<InterestScreen> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: const Text('관심종목'),
+        title: const Text('관심종목',
+            style: TextStyle(fontWeight: FontWeight.w700, fontSize: 18)),
         backgroundColor: Colors.white,
         foregroundColor: Colors.black,
         centerTitle: true,
+        actions: [
+          IconButton(onPressed: () {/* 설정 */}, icon: const Icon(Icons.settings)),
+          IconButton(onPressed: () {/* 추가 */}, icon: const Icon(Icons.add)),
+        ],
       ),
-      // 관심종목 데이터를 비동기적으로 가져와 화면에 표시
-      body: FutureBuilder<List<StockItem>>(
-        future: _watchlistFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return Center(child: Text('오류 발생: ${snapshot.error}'));
-          }
-          final items = snapshot.data ?? [];
-          if (items.isEmpty) {
-            return const Center(child: Text('관심종목이 없습니다'));
-          }
-          return RefreshIndicator(
-            onRefresh: _reload,
-            child: ListView.builder(
-              itemCount: items.length,
-              itemBuilder: (context, index) {
-                final stock = items[index];
-                return GestureDetector(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => DetailScreen(stock: stock),
-                      ),
-                    );
-                  },
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-                    child: Row(
-                      children: [
-                        Expanded(child: StockItems(stock: stock)),
-                        // 하트 아이콘을 눌러 관심목록에서 제거할 수 있음
-                        IconButton(
-                          icon: const Icon(Icons.favorite, color: Colors.red),
-                          onPressed: () async {
-                            await _apiService.removeFromWatchlist(stock.stockId.toString());
-                            _reload();
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              },
+      body: SafeArea(
+        child: Column(
+          children: const [
+            Expanded(
+              child: WatchlistView(),
             ),
-          );
-        },
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/common/InfoCardGroup.dart
+++ b/lib/widgets/common/InfoCardGroup.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
 
 class InfoCardGroup extends StatelessWidget {
-  final String title;
+  final String? title;
   final List<Map<String, dynamic>> rows; // 변경된 타입
 
   const InfoCardGroup({
     super.key,
-    required this.title,
+    this.title,
     required this.rows,
   });
 
   @override
   Widget build(BuildContext context) {
+    final hasTitle = (title != null && title!.isNotEmpty); //title 유무
+
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Padding(
@@ -19,8 +21,8 @@ class InfoCardGroup extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(title, style: CardStyles.title),
-            const SizedBox(height: 10),
+            if (hasTitle) Text(title!, style: CardStyles.title),  //title 존재시 출력
+            if (hasTitle) const SizedBox(height: 10),
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
@@ -39,6 +41,7 @@ class InfoCardGroup extends StatelessWidget {
                     children: rows.map((row) {
                       final label = row['label'] as String;
                       final value = row['value'] as String;
+                      final String? subValue = row['subValue']?.toString();
                       final color = row['color'] as Color? ?? Colors.black; // 기본값 검정
 
                       return SizedBox(
@@ -52,6 +55,8 @@ class InfoCardGroup extends StatelessWidget {
                               value,
                               style: CardStyles.cost.copyWith(color: color),
                             ),
+                            if (subValue != null && subValue.isNotEmpty) // 값 있을 때만 출력
+                              Text(subValue, style: CardStyles.subvalue.copyWith(color: color)),
                           ],
                         ),
                       );
@@ -84,5 +89,10 @@ class CardStyles {
   static const TextStyle cost = TextStyle(
     fontWeight: FontWeight.w600,
     fontSize: 16,
+  );
+
+  static const TextStyle subvalue = TextStyle(
+    fontWeight: FontWeight.w600,
+    fontSize: 12,
   );
 }

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/models/pattern_apply.dart';
+import 'package:stockapp/widgets/common/InfoCardGroup.dart';
+
+class BacktestResultCard extends StatelessWidget {
+  final BacktestResult result;
+  const BacktestResultCard({required this.result});
+
+  String _fmtPct(num v, {bool isRatio = false}) {
+    final p = isRatio ? v * 100 : v;
+    return '${p.toStringAsFixed(2)}%';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+          padding: const EdgeInsets.all(14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 기간/실행일
+              Text('기간 ${result.startDate} ~ ${result.endDate}'),
+              Row(
+                children: [
+                  Text('실행 날짜 ${result.executedAt}',
+                      style: TextStyle(color: Colors.grey.shade600, fontSize: 14)),
+                  const Spacer(),
+                  Text('매칭 횟수 : ${result.matchedCount}'),
+                ],
+              ),
+              const SizedBox(height: 12),
+
+              // 지표들
+              InfoCardGroup(
+                rows: [
+                  {'label': '승률', 'value': _fmtPct(result.winRate)},
+                  {'label': '평균 수익', 'value': _fmtPct(result.averageReturn, isRatio: true), 'color': const Color(0xFF289BF6)},
+                  {'label': '최대 수익', 'value': _fmtPct(result.maxReturn), 'subValue': result.maxReturnDate,'color': const Color(0xFF289BF6)},
+                ],),
+
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  onPressed: () {
+                    // TODO: 재실행 API 있으면 호출 후 상단 RefreshIndicator로 갱신
+                  },
+                  label: const Text('다시 돌리기'),
+                ),
+              ),
+            ],
+          )
+    );
+
+  }
+}
+
+class _Metric extends StatelessWidget {
+  final String label;
+  final String value;
+  const _Metric({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.only(right: 10, bottom: 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label,
+                style: TextStyle(fontSize: 12, color: Colors.grey.shade600)),
+            const SizedBox(height: 4),
+            Text(value,
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/interest/WatchlistAppBarActions.dart
+++ b/lib/widgets/interest/WatchlistAppBarActions.dart
@@ -1,0 +1,119 @@
+// lib/screens/watchlist/watchlist_view.dart (핵심 부분만)
+import 'package:flutter/material.dart';
+import 'package:stockapp/data/interestlist_api.dart';
+import 'package:stockapp/data/recent_api.dart';
+import 'package:stockapp/models/stock.dart';
+import '../../models/stock_brief.dart';
+import '../../widgets/common/TopTabSelector.dart';
+import '../../widgets/interest/WatchlistItem.dart';
+
+class WatchlistView extends StatefulWidget {
+  const WatchlistView({super.key});
+  @override
+  State<WatchlistView> createState() => _WatchlistViewState();
+}
+
+class _WatchlistViewState extends State<WatchlistView> {
+  final _tabs = const ['관심', '최근'];
+  int _selectedIndex = 0;
+  final _pageController = PageController();
+
+  final _api = InterestlistApi();
+  final _recentApi = RecentApi();
+
+  late Future<List<StockBrief>> _watchFuture;
+  late Future<List<StockBrief>> _recentFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _watchFuture = _api.fetchWatchlist();
+    _recentFuture = _recentApi.fetchRecent();
+  }
+
+  Future<void> _reloadCurrent() async {
+    setState(() {
+      if (_selectedIndex == 0) {
+        _watchFuture = _api.fetchWatchlist();
+      } else {
+        _recentFuture = _recentApi.fetchRecent();
+      }
+    });
+    await (_selectedIndex == 0 ? _watchFuture : _recentFuture);
+  }
+
+  void _onTabTap(int index) {
+    setState(() => _selectedIndex = index);
+    _pageController.animateToPage(index,
+        duration: const Duration(milliseconds: 220), curve: Curves.easeOut);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 8),
+        TopTabSelector(tabs: _tabs, selectedIndex: _selectedIndex, onTap: _onTabTap),
+        const SizedBox(height: 8),
+        Expanded(
+          child: PageView(
+            controller: _pageController,
+            onPageChanged: (i) => setState(() => _selectedIndex = i),
+            children: [
+              _WatchlistListFuture(future: _watchFuture, onRefresh: _reloadCurrent),
+              _WatchlistListFuture(future: _recentFuture, onRefresh: _reloadCurrent),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WatchlistListFuture extends StatelessWidget {
+  final Future<List<StockBrief>> future;
+  final Future<void> Function() onRefresh;
+  const _WatchlistListFuture({required this.future, required this.onRefresh});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<StockBrief>>(
+      future: future,
+      builder: (context, snap) {
+        if (snap.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snap.hasError) {
+          return Center(
+            child: TextButton.icon(
+              onPressed: onRefresh,
+              icon: const Icon(Icons.refresh),
+              label: Text('불러오기 실패: ${snap.error}'),
+            ),
+          );
+        }
+        final items = snap.data ?? const <StockBrief>[];
+        return RefreshIndicator(
+          onRefresh: onRefresh,
+          child: ListView.builder(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount: items.length,
+            itemBuilder: (context, i) {
+              final s = items[i];
+              return WatchlistItem(
+                stock: Stock(id: s.id, name: s.name, imageUrl: s.imageUrl),
+                onTap: () {},
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/interest/WatchlistItem.dart
+++ b/lib/widgets/interest/WatchlistItem.dart
@@ -1,5 +1,6 @@
 // screens/watchlist/widgets/watchlist_item.dart
 import 'package:flutter/material.dart';
+import 'package:stockapp/screens/interest_pattern_screen.dart';
 import '../../../models/stock.dart';
 
 class WatchlistItem extends StatelessWidget {
@@ -99,7 +100,13 @@ class WatchlistItem extends StatelessWidget {
               padding: const EdgeInsets.only(left: 8),
               child: OutlinedButton(
                 onPressed: () {
-                  /* 패턴 화면 */
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => InterestPatternScreen(
+                            /*넘겨줄 값*/
+                      ),
+                    ),
+                  );
                 },
                 style: OutlinedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(

--- a/lib/widgets/interest/WatchlistItem.dart
+++ b/lib/widgets/interest/WatchlistItem.dart
@@ -1,0 +1,151 @@
+// screens/watchlist/widgets/watchlist_item.dart
+import 'package:flutter/material.dart';
+import '../../../models/stock.dart';
+
+class WatchlistItem extends StatelessWidget {
+  final Stock stock;
+  final VoidCallback? onTap;
+
+  const WatchlistItem({super.key, required this.stock, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    // final up = stock.changePct >= 0;
+    // final changeText =
+    //     '${up ? '+' : ''}${stock.changePct.toStringAsFixed(2)}%';
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: [
+            // 종목 이미지
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 5),
+              child: ClipOval(
+                child: Image.network(
+                  stock.imageUrl,
+                  width: 40,
+                  height: 40,
+                  fit: BoxFit.cover,
+                  errorBuilder:
+                      (context, error, stackTrace) => Container(
+                        width: 40,
+                        height: 40,
+                        color: const Color(0xFFF8FAFB),
+                        child: const Icon(
+                          Icons.image_not_supported,
+                          color: Colors.grey,
+                        ),
+                      ),
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) return child;
+                    return Container(
+                      width: 40,
+                      height: 40,
+                      color: const Color(0xFFF8FAFB),
+                      child: const Center(
+                        child: SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+
+            const SizedBox(width: 10),
+
+            // 종목명
+            Expanded(
+              flex: 2,
+              child: Text(stock.name, style: TextStyles.symbolText),
+            ),
+
+            // 3) 가격/변동률
+            // Column(
+            //   crossAxisAlignment: CrossAxisAlignment.end,
+            //   children: [
+            //     Text('\$${stock.price.toStringAsFixed(2)}',
+            //         style: const TextStyle(
+            //             fontSize: 16, fontWeight: FontWeight.w600)),
+            //     const SizedBox(height: 4),
+            //     Container(
+            //       padding:
+            //       const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            //       decoration: BoxDecoration(
+            //         color: up ? Colors.green.withOpacity(.1) : Colors.red.withOpacity(.1),
+            //         borderRadius: BorderRadius.circular(999),
+            //       ),
+            //       child: Text(
+            //         changeText,
+            //         style: TextStyle(
+            //           fontSize: 12,
+            //           color: up ? Colors.green : Colors.red,
+            //           fontWeight: FontWeight.w600,
+            //         ),
+            //       ),
+            //     ),
+            //   ],
+            // ),
+            const SizedBox(width: 8),
+
+            // 4) 패턴 버튼
+            Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: OutlinedButton(
+                onPressed: () {
+                  /* 패턴 화면 */
+                },
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 15,
+                    vertical: 9,
+                  ),
+                  // 내부 여백 축소
+                  minimumSize: const Size(0, 0),
+                  // 기본 최소 크기 없애기
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  // 터치 타겟 축소 허용
+                  backgroundColor: const Color(0xFF000000),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text(
+                  '패턴',
+                  style: TextStyle(fontSize: 14, color: Colors.white),
+                ),
+              ),
+            ),
+
+            // 5) 알림 벨
+            IconButton(
+              onPressed: () {
+                /* 알림 토글 */
+              },
+              icon: Icon(Icons.notifications_none),
+              splashRadius: 20,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TextStyles {
+  static const TextStyle costText = TextStyle(
+    fontWeight: FontWeight.w600,
+    fontSize: 14,
+  );
+
+  static const TextStyle symbolText = TextStyle(
+    fontSize: 15,
+    fontWeight: FontWeight.w600,
+  );
+}

--- a/lib/widgets/interest/WatchlistItem.dart
+++ b/lib/widgets/interest/WatchlistItem.dart
@@ -104,6 +104,8 @@ class WatchlistItem extends StatelessWidget {
                     MaterialPageRoute(
                       builder: (_) => InterestPatternScreen(
                             /*넘겨줄 값*/
+                        stockId: stock.id,       // 모델에 맞게 전달
+                        stockName: stock.name,
                       ),
                     ),
                   );

--- a/lib/widgets/interest/pattern_chart_card.dart
+++ b/lib/widgets/interest/pattern_chart_card.dart
@@ -1,0 +1,21 @@
+// lib/widgets/interest/pattern/pattern_chart_card.dart
+import 'package:flutter/material.dart';
+
+class PatternChartCard extends StatelessWidget {
+  final List<num> points;
+  const PatternChartCard({super.key, required this.points});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: fl_chart 등으로 라인차트 교체
+    return Container(
+      height: 180,
+      decoration: BoxDecoration(
+        color: Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: const Center(child: Text('패턴 라인 차트 영역')),
+    );
+  }
+}

--- a/lib/widgets/interest/pattern_chip.dart
+++ b/lib/widgets/interest/pattern_chip.dart
@@ -1,0 +1,19 @@
+// lib/widgets/interest/pattern/pattern_chip.dart
+import 'package:flutter/material.dart';
+
+class PatternChip extends StatelessWidget {
+  final String text;
+  const PatternChip({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade200,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(text, style: const TextStyle(fontSize: 12)),
+    );
+  }
+}

--- a/lib/widgets/interest/pattern_controls_row.dart
+++ b/lib/widgets/interest/pattern_controls_row.dart
@@ -1,0 +1,33 @@
+// lib/widgets/interest/pattern/pattern_controls_row.dart
+import 'package:flutter/material.dart';
+import 'package:stockapp/widgets/interest/pattern_chip.dart';
+
+class PatternControlsRow extends StatelessWidget {
+  final String periodText;
+  final String toleranceText;
+  final VoidCallback? onDelete;
+  final VoidCallback? onEdit;
+
+  const PatternControlsRow({
+    super.key,
+    required this.periodText,
+    required this.toleranceText,
+    this.onDelete,
+    this.onEdit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        PatternChip(text: periodText),
+        const SizedBox(width: 8),
+        PatternChip(text: toleranceText),
+        const Spacer(),
+        OutlinedButton(onPressed: onDelete, child: const Text('삭제')),
+        const SizedBox(width: 8),
+        FilledButton.tonal(onPressed: onEdit, child: const Text('수정')),
+      ],
+    );
+  }
+}

--- a/lib/widgets/interest/pattern_empty_view.dart
+++ b/lib/widgets/interest/pattern_empty_view.dart
@@ -1,0 +1,30 @@
+// lib/widgets/interest/pattern/pattern_empty_view.dart
+import 'package:flutter/material.dart';
+import 'package:stockapp/widgets/interest/pattern_section_header.dart';
+
+class PatternEmptyView extends StatelessWidget {
+  const PatternEmptyView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        const PatternSectionHeader(title: '내 전략 패턴'),
+        const SizedBox(height: 40),
+        Center(
+          child: Column(
+            children: [
+              const Text('설정된 차트 패턴이 없습니다.'),
+              const SizedBox(height: 10),
+              FilledButton(
+                onPressed: () {/* 패턴 추가 화면 이동 */},
+                child: const Text('패턴 추가하기'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -1,0 +1,63 @@
+// lib/widgets/interest/pattern/pattern_exists_view.dart
+import 'package:flutter/material.dart';
+import 'package:stockapp/models/pattern_apply.dart';
+import 'package:stockapp/widgets/interest/BacktestResultCard.dart';
+import 'package:stockapp/widgets/interest/pattern_chart_card.dart';
+import 'package:stockapp/widgets/interest/pattern_controls_row.dart';
+import 'package:stockapp/widgets/interest/pattern_section_header.dart';
+
+class PatternExistsView extends StatelessWidget {
+  final PatternApply data;
+  final VoidCallback? onDelete;
+  final VoidCallback? onEdit;
+  final VoidCallback? onRunBacktest;
+
+  const PatternExistsView({
+    super.key,
+    required this.data,
+    this.onDelete,
+    this.onEdit,
+    this.onRunBacktest,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final patt = data.pattern!;
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const PatternSectionHeader(title: '내 전략 패턴'),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: PatternChartCard(points: patt.points), // 차트 위젯 분리
+        ),
+        const SizedBox(height: 12),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: PatternControlsRow(
+            periodText: '기간: ${patt.periodValue} ${patt.periodUnit}',
+            toleranceText: '허용오차: ${patt.tolerance}',
+            onDelete: onDelete,
+            onEdit: onEdit,
+          ),
+        ),
+        const SizedBox(height: 20),
+
+        const PatternSectionHeader(title: '최근 백테스팅 결과'),
+        if (data.hasBacktest)
+          BacktestResultCard(result: data.backtest!)
+        else
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: OutlinedButton.icon(
+              onPressed: onRunBacktest,
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('백테스팅 진행하기'),
+            ),
+          ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}

--- a/lib/widgets/interest/pattern_section_header.dart
+++ b/lib/widgets/interest/pattern_section_header.dart
@@ -1,0 +1,15 @@
+// lib/widgets/interest/pattern/pattern_section_header.dart
+import 'package:flutter/material.dart';
+
+class PatternSectionHeader extends StatelessWidget {
+  final String title;
+  const PatternSectionHeader({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+    );
+  }
+}

--- a/lib/widgets/interest/pattern_stock_header.dart
+++ b/lib/widgets/interest/pattern_stock_header.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class StockHeader extends StatelessWidget {
+  final String name;
+  final String? imageUrl;
+
+  const StockHeader({super.key, required this.name, this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    Widget avatar;
+    if (imageUrl != null && imageUrl!.isNotEmpty) {
+      avatar = ClipOval(
+        child: Image.network(
+          imageUrl!,
+          width: 40, height: 40, fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => _fallback(name),
+          loadingBuilder: (c, child, p) =>
+          p == null ? child : _loading(),
+        ),
+      );
+    } else {
+      avatar = _fallback(name);  // 빈/널이면 플레이스홀더
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: Row(
+        children: [
+          avatar,
+          const SizedBox(width: 10),
+          Expanded(child: Text(name,
+              style: const TextStyle(fontSize: 27, fontWeight: FontWeight.w700))),
+        ],
+      ),
+    );
+  }
+
+  Widget _fallback(String name) => CircleAvatar(
+    radius: 20,
+    backgroundColor: const Color(0xFFF1F3F5),
+    child: Text(
+      name.isNotEmpty ? name.characters.first : '?',
+      style: const TextStyle(fontWeight: FontWeight.w700),
+    ),
+  );
+
+  Widget _loading() => const SizedBox(
+    width: 40, height: 40,
+    child: Center(child: SizedBox(
+        width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))),
+  );
+}

--- a/lib/widgets/stock_details/stockName.dart
+++ b/lib/widgets/stock_details/stockName.dart
@@ -13,8 +13,15 @@ class StockName extends StatefulWidget {
 }
 
 class _StockNameState extends State<StockName> {
-  bool isFavorite = false;
+  late bool isFavorite;
+  bool _busy = false;
   final WatchlistApiService _apiService2 = WatchlistApiService();
+
+  @override
+  void initState() {
+    super.initState();
+    isFavorite = widget.detail.isWatchlist;  // API값으로 초기화
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,6 +50,7 @@ class _StockNameState extends State<StockName> {
 
                 setState(() {
                   isFavorite = !isFavorite;
+                  _busy = true;
                 });
 
                 try {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -260,10 +260,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -481,10 +481,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
 관심 종목 페이지 구현 + api 연동

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39 

## ⏳ 작업 내용
- 관심 종목 페이지 구현
- 관심 종목 조회 api 연동 완료
- 최근 조회 종목 api 연동 완료
- 종목-패턴 상세 조회 api 연동 완료

## 📸 스크린샷

https://github.com/user-attachments/assets/ed1668e8-4a3f-42c5-bf1a-0529fef40e39



## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 종목 패턴 부분은 추후 구현 예정입니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 관심/최근 탭으로 구성된 워치리스트 화면 추가(스와이프/탭 전환, 풀투리프레시, 로딩/에러 재시도).
  - 관심 종목의 패턴 상세 화면 추가: 패턴 차트 카드(placeholder), 기간/허용오차 칩, 삭제/수정 버튼, 백테스트 결과 카드 및 실행 버튼.
  - 종목 헤더, 패턴 섹션 헤더, 리스트 아이템 등 공용 UI 컴포넌트 추가.

- 스타일
  - 정보 카드 그룹에 선택적 제목 및 보조 값(subValue) 표시 스타일 추가.

- 버그 수정
  - 종목 즐겨찾기 상태가 초기 로드 시 API 값과 일치하도록 초기화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->