### PR TITLE
[FEAT] 패턴 출력, 패턴 알림,삭제 api 연동

### DIFF
--- a/lib/data/pattern_apply_api.dart
+++ b/lib/data/pattern_apply_api.dart
@@ -1,0 +1,51 @@
+import 'package:dio/dio.dart';
+import 'package:stockapp/data/dio_client.dart';
+
+class PatternApplyApi {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://pattern-catcher.net:8080',
+      connectTimeout: const Duration(seconds: 8),
+      receiveTimeout: const Duration(seconds: 8),
+      // 4xx도 우리가 직접 분기해서 처리
+      validateStatus: (s) => s != null && s < 500,
+    ),
+  )..interceptors.add(LogInterceptor(
+      requestBody: true, responseBody: true, requestHeader: false, responseHeader: false));
+
+  /// 적용 패턴 삭제
+  Future<void> delete(int patternApplyId) async {
+    final res = await dio.delete('/pattern-applies/$patternApplyId');
+    if (res.statusCode == 200 && res.data is Map<String, dynamic>) {
+      final data = res.data as Map<String, dynamic>;
+      if (data['isSuccess'] == true) return;
+      throw Exception(data['message'] ?? '패턴 해제 실패');
+    }
+    throw Exception('HTTP ${res.statusCode}');
+  }
+
+  /// 성공 시: true/false (서버가 상태를 반환한 경우)
+  /// 성공하지만 상태 미반환 시: null
+  /// 실패 시: 예외
+  Future<bool?> toggleNotification(int patternApplyId) async {
+    final res = await dio.patch('/pattern-applies/$patternApplyId/notification');
+
+    // 디버깅 시에 켜두세요
+    // print('toggleNotification status=${res.statusCode} data=${res.data}');
+
+    if (res.statusCode == 200 && res.data is Map<String, dynamic>) {
+      final data = res.data as Map<String, dynamic>;
+      if (data['isSuccess'] == true) {
+        final result = data['result'];
+        if (result is Map && result['isAlertEnabled'] is bool) {
+          return result['isAlertEnabled'] as bool;
+        }
+        // 성공이지만 상태필드가 없으면 null 반환 (UI는 낙관적 토글 유지)
+        return null;
+      }
+      // 서버가 성공이 아닌 이유 전달
+      throw Exception(data['message'] ?? '알림 토글 실패');
+    }
+    throw Exception('HTTP ${res.statusCode}');
+  }
+}

--- a/lib/models/pattern_apply.dart
+++ b/lib/models/pattern_apply.dart
@@ -5,12 +5,18 @@ class PatternApply {
   final PatternInfo? pattern;
   final BacktestResult? backtest;
 
+  final int? patternApplyId;
+  final bool? isAlertEnabled;
+
   PatternApply({
     required this.stockId,
     required this.stockName,
     required this.stockImage,
     required this.pattern,
     required this.backtest,
+
+    this.patternApplyId,
+    this.isAlertEnabled,
   });
 
   factory PatternApply.fromJson(Map<String, dynamic> json) {
@@ -25,6 +31,9 @@ class PatternApply {
       stockImage: stock['stockImage'] as String? ?? '',
       pattern: patt == null ? null : PatternInfo.fromJson(patt),
       backtest: bt == null ? null : BacktestResult.fromJson(bt),
+
+      patternApplyId: r['patternApplyId'] as int?,
+      isAlertEnabled: r['isAlertEnabled'] as bool?,
     );
   }
 

--- a/lib/screens/interest_pattern_screen.dart
+++ b/lib/screens/interest_pattern_screen.dart
@@ -1,6 +1,7 @@
 // lib/screens/interest/interest_pattern_screen.dart
 import 'package:flutter/material.dart';
 import 'package:stockapp/data/interest_pattern_api.dart';
+import 'package:stockapp/data/pattern_apply_api.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/interest/pattern_empty_view.dart';
 import 'package:stockapp/widgets/interest/pattern_exists_view.dart';
@@ -19,6 +20,7 @@ class InterestPatternScreen extends StatefulWidget {
 class _InterestPatternScreenState extends State<InterestPatternScreen> {
   final _api = PatternApi();
   late Future<PatternApply?> _future;
+  final _applyApi = PatternApplyApi(); // delete 호출
 
   @override
   void initState() {
@@ -31,9 +33,49 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
     await _future;
   }
 
+  Future<void> _confirmAndDelete(int patternApplyId) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('전략 패턴을 삭제하시겠습니까?'),
+        content: const Text('이 동작은 취소할 수 없으며 내 전략 차트가 삭제됩니다.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('취소')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('삭제')),
+        ],
+      ),
+    );
+
+    if (ok != true) return;
+
+    try {
+      await _applyApi.delete(patternApplyId);
+
+      if (!mounted) return;
+
+      // ★ 1) 낙관적 갱신: 즉시 EmptyView로 전환
+      setState(() {
+        _future = Future<PatternApply?>.value(null);
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('패턴이 해제되었습니다.')),
+      );
+
+      // ★ 2) 서버 상태 동기화: 약간의 지연 후 재조회(백엔드 반영 지연 대비)
+      await Future.delayed(const Duration(milliseconds: 150));
+      _reload();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('패턴 해제 실패: $e')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<PatternApply?>(
+    return FutureBuilder<PatternApply?>( // 그대로 OK
       future: _future,
       builder: (context, snap) {
         if (snap.connectionState == ConnectionState.waiting) {
@@ -60,7 +102,7 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
         final hasPattern = data != null && data.hasPattern;
 
         return Scaffold(
-          appBar: AppBar(),
+          appBar: AppBar(backgroundColor: Colors.white),
           backgroundColor: Colors.white,
           body: RefreshIndicator(
             onRefresh: _reload,
@@ -71,7 +113,16 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
                   child: hasPattern
                       ? PatternExistsView(
                     data: data!,
-                    onDelete: () {/* TODO */},
+                    onDelete: () {
+                      final id = data.patternApplyId;
+                      if (id == null) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('패턴 식별자를 찾을 수 없습니다.')),
+                        );
+                        return;
+                      }
+                      _confirmAndDelete(id);
+                    },
                     onEdit: () {/* TODO */},
                     onRunBacktest: () {/* TODO */},
                   )

--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -43,7 +43,7 @@ class MypageScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      : AppBar(
+      appBar: AppBar(
         title: const Text('마이페이지'),
       ),
       body: Padding(

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -41,11 +41,28 @@ class BacktestResultCard extends StatelessWidget {
               const SizedBox(height: 12),
               Align(
                 alignment: Alignment.centerRight,
-                child: TextButton.icon(
+                child: ElevatedButton(
                   onPressed: () {
                     // TODO: 재실행 API 있으면 호출 후 상단 RefreshIndicator로 갱신
                   },
-                  label: const Text('다시 돌리기'),
+                  style:  ElevatedButton.styleFrom(
+                // 메인 컬러
+                // primary: Colors.red, // Deprecated
+                // 텍스트색상, ripple컬러
+                foregroundColor: Colors.white,
+                  // 버튼 배경 색
+                  backgroundColor: Colors.black,
+                  textStyle:
+                  TextStyle(fontWeight: FontWeight.w500, fontSize: 12),
+                  // 글자 주변에 적용
+                  padding: EdgeInsets.all(12),
+                  // 테두리 설정
+                  side: BorderSide( color: Colors.black, width: 1),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8)
+                  ),
+                ),
+                  child: const Text('다시 돌리기'),
                 ),
               ),
             ],

--- a/lib/widgets/interest/WatchlistItem.dart
+++ b/lib/widgets/interest/WatchlistItem.dart
@@ -1,6 +1,7 @@
 // screens/watchlist/widgets/watchlist_item.dart
 import 'package:flutter/material.dart';
 import 'package:stockapp/screens/interest_pattern_screen.dart';
+import 'package:stockapp/widgets/interest/pattern_alert_button.dart';
 import '../../../models/stock.dart';
 
 class WatchlistItem extends StatelessWidget {
@@ -132,15 +133,7 @@ class WatchlistItem extends StatelessWidget {
               ),
             ),
 
-            // 5) 알림 벨
-            IconButton(
-              onPressed: () {
-                /* 알림 토글 */
-              },
-              icon: Icon(Icons.notifications_none),
-              splashRadius: 20,
-            ),
-          ],
+           ]
         ),
       ),
     );

--- a/lib/widgets/interest/pattern_alert_button.dart
+++ b/lib/widgets/interest/pattern_alert_button.dart
@@ -1,0 +1,72 @@
+// lib/widgets/interest/pattern/pattern_alert_button.dart
+import 'package:flutter/material.dart';
+import 'package:stockapp/data/pattern_apply_api.dart';
+
+class PatternAlertButton extends StatefulWidget {
+  final int patternApplyId;
+  final bool initialEnabled;
+  const PatternAlertButton({
+    super.key,
+    required this.patternApplyId,
+    this.initialEnabled = false,
+  });
+
+  @override
+  State<PatternAlertButton> createState() => _PatternAlertButtonState();
+}
+
+class _PatternAlertButtonState extends State<PatternAlertButton> {
+  bool _enabled = false;
+  bool _busy = false;
+  final _api = PatternApplyApi();
+
+  @override
+  void initState() {
+    super.initState();
+    _enabled = widget.initialEnabled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      splashRadius: 20,
+      onPressed: _busy ? null : () async {
+        final prev = _enabled;
+
+        // 낙관적 토글
+        setState(() {
+          _busy = true;
+          _enabled = !prev;
+
+        });
+
+        try {
+          final server = await _api.toggleNotification(widget.patternApplyId);
+          if (server != null) {
+            // 서버가 명확한 상태를 주면 그 값으로 보정
+            setState(() => _enabled = server);
+          }
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(_enabled ? '알림이 켜졌습니다.' : '알림이 꺼졌습니다.')),
+          );
+        } catch (e) {
+          // 실패 시 롤백
+          setState(() => _enabled = prev);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('알림 설정 실패: $e')),
+          );
+        } finally {
+          setState(() => _busy = false);
+        }
+
+        print('toggle notif: patternApplyId=${widget.patternApplyId}');
+      },
+      icon: Icon(
+        _enabled ? Icons.notifications_active : Icons.notifications_none,
+        color: _enabled ? const Color(0xFF000000) : null,
+      ),
+      tooltip: _enabled ? '알림 끄기' : '알림 켜기',
+    );
+  }
+}
+

--- a/lib/widgets/interest/pattern_chart_card.dart
+++ b/lib/widgets/interest/pattern_chart_card.dart
@@ -1,21 +1,145 @@
 // lib/widgets/interest/pattern/pattern_chart_card.dart
+import 'dart:math';
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class PatternChartCard extends StatelessWidget {
-  final List<num> points;
-  const PatternChartCard({super.key, required this.points});
+  final List<num> points;          // API의 pattern.points
+  final double? tolerancePct;      // API의 tolerance(%)이면 2.5 -> 2.5
+  final EdgeInsets padding;
+
+  const PatternChartCard({
+    super.key,
+    required this.points,
+    this.tolerancePct,
+    this.padding = const EdgeInsets.all(12),
+  });
 
   @override
   Widget build(BuildContext context) {
-    // TODO: fl_chart 등으로 라인차트 교체
+    if (points.length < 2) {
+      return _placeholder();
+    }
+
+    // spots 변환 (x = 인덱스, y = 값)
+    final spots = List<FlSpot>.generate(
+      points.length,
+          (i) => FlSpot(i.toDouble(), points[i].toDouble()),
+    );
+
+    // y축 범위 계산 + 여유 패딩
+    final ys = points.map((e) => e.toDouble()).toList();
+    double minY = ys.reduce(min);
+    double maxY = ys.reduce(max);
+    final pad = max(1.0, (maxY - minY) * 0.1);
+    minY -= pad;
+    maxY += pad;
+
+    // 허용오차 밴드(선택)
+    LineChartBarData? upperLine;
+    LineChartBarData? lowerLine;
+    List<BetweenBarsData>? between;
+
+    if (tolerancePct != null && tolerancePct! > 0) {
+      final tol = tolerancePct! / 100.0;
+      final uppers = List<FlSpot>.generate(
+        points.length, (i) => FlSpot(i.toDouble(), ys[i] * (1 + tol)),
+      );
+      final lowers = List<FlSpot>.generate(
+        points.length, (i) => FlSpot(i.toDouble(), ys[i] * (1 - tol)),
+      );
+
+      upperLine = LineChartBarData(
+        spots: uppers,
+        isCurved: true,
+        barWidth: 0,                       // 선은 보이지 않게
+        dotData: const FlDotData(show: false),
+        color: Colors.transparent,
+      );
+      lowerLine = LineChartBarData(
+        spots: lowers,
+        isCurved: true,
+        barWidth: 0,
+        dotData: const FlDotData(show: false),
+        color: Colors.transparent,
+      );
+      between = [
+        BetweenBarsData(
+          fromIndex: 1, // lowerLine의 인덱스 (아래에서 순서 맞춰줌)
+          toIndex: 0,   // upperLine의 인덱스
+          color: Colors.amber.withOpacity(0.12),
+        ),
+      ];
+
+      // y범위 재보정(밴드가 더 넓어질 수 있음)
+      minY = min(minY, lowers.map((e) => e.y).reduce(min));
+      maxY = max(maxY, uppers.map((e) => e.y).reduce(max));
+    }
+
+    // 메인 패턴 선
+    final patternLine = LineChartBarData(
+      spots: spots,
+      isCurved: true,
+      barWidth: 2,
+      color: Colors.amber,                 // 디자인에 맞게
+      dotData: const FlDotData(show: true),
+    );
+
+    // 라벨/그리드 최소화
+    final titles = FlTitlesData(
+      bottomTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+    );
+
     return Container(
       height: 180,
+      padding: padding,
       decoration: BoxDecoration(
         color: Colors.grey.shade100,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: Colors.grey.shade300),
       ),
-      child: const Center(child: Text('패턴 라인 차트 영역')),
+      child: LineChart(
+        LineChartData(
+          minY: minY,
+          maxY: maxY,
+          minX: 0,
+          maxX: (spots.length - 1).toDouble(),
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: (maxY - minY) / 4,
+            getDrawingHorizontalLine: (_) => FlLine(
+              color: Colors.grey.withOpacity(0.2),
+              strokeWidth: 1,
+            ),
+          ),
+          titlesData: titles,
+          borderData: FlBorderData(show: false),
+          lineBarsData: [
+            // betweenBars를 쓰려면 순서: [upper, lower, main]
+            if (upperLine != null) upperLine,
+            if (lowerLine != null) lowerLine,
+            patternLine,
+          ],
+          betweenBarsData: between ?? const [],
+        ),
+      ),
+    );
+  }
+
+  Widget _placeholder() {
+    return Container(
+      height: 180,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade300),
+      ),
+      child: const Text('표시할 패턴 데이터가 없습니다.'),
     );
   }
 }

--- a/lib/widgets/interest/pattern_controls_row.dart
+++ b/lib/widgets/interest/pattern_controls_row.dart
@@ -24,9 +24,47 @@ class PatternControlsRow extends StatelessWidget {
         const SizedBox(width: 8),
         PatternChip(text: toleranceText),
         const Spacer(),
-        OutlinedButton(onPressed: onDelete, child: const Text('삭제')),
+        ElevatedButton(
+          onPressed: onDelete,
+          style: ElevatedButton.styleFrom(
+            // 메인 컬러
+            // primary: Colors.red, // Deprecated
+            // 텍스트색상, ripple컬러
+            foregroundColor: Colors.black,
+            // 버튼 배경 색
+            backgroundColor: Color(0xFFF5F5F5),
+            textStyle: TextStyle(fontWeight: FontWeight.w500, fontSize: 12),
+            // 글자 주변에 적용
+            padding: EdgeInsets.all(12),
+            // 테두리 설정
+            side: BorderSide(color: Colors.black, width: 1),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+          child: Text('삭제'),
+        ),
         const SizedBox(width: 8),
-        FilledButton.tonal(onPressed: onEdit, child: const Text('수정')),
+        ElevatedButton(
+          onPressed: onEdit,
+          style: ElevatedButton.styleFrom(
+            // 메인 컬러
+            // primary: Colors.red, // Deprecated
+            // 텍스트색상, ripple컬러
+            foregroundColor: Colors.white,
+            // 버튼 배경 색
+            backgroundColor: Colors.black,
+            textStyle: TextStyle(fontWeight: FontWeight.w500, fontSize: 12),
+            // 글자 주변에 적용
+            padding: EdgeInsets.all(12),
+            // 테두리 설정
+            side: BorderSide(color: Colors.black, width: 1),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+          child: Text('수정'),
+        ),
       ],
     );
   }

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/interest/BacktestResultCard.dart';
+import 'package:stockapp/widgets/interest/pattern_alert_button.dart';
 import 'package:stockapp/widgets/interest/pattern_chart_card.dart';
 import 'package:stockapp/widgets/interest/pattern_controls_row.dart';
 import 'package:stockapp/widgets/interest/pattern_section_header.dart';
@@ -25,14 +26,40 @@ class PatternExistsView extends StatelessWidget {
     final patt = data.pattern!;
 
     return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
-        const PatternSectionHeader(title: '내 전략 패턴'),
+        // 헤더 + 알림 버튼 행
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: PatternChartCard(points: patt.points), // 차트 위젯 분리
+          child: Row(
+            children: [
+              const Expanded(
+                child: PatternSectionHeader(title: '내 전략 패턴'),
+              ),
+              if (data.patternApplyId != null)
+                PatternAlertButton(
+                  patternApplyId: data.patternApplyId!,
+                  initialEnabled: data.isAlertEnabled ?? false, // 모델에 없으면 false
+                )
+              else
+                IconButton(
+                  onPressed: null,
+                  icon: const Icon(Icons.notifications_none),
+                  tooltip: '패턴 적용 후 사용 가능',
+                ),
+            ],
+          ),
+        ),
+
+        // 차트
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: PatternChartCard(points: patt.points),
         ),
         const SizedBox(height: 12),
+
+        // 컨트롤
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: PatternControlsRow(
@@ -44,6 +71,7 @@ class PatternExistsView extends StatelessWidget {
         ),
         const SizedBox(height: 20),
 
+        // 백테스팅
         const PatternSectionHeader(title: '최근 백테스팅 결과'),
         if (data.hasBacktest)
           BacktestResultCard(result: data.backtest!)


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
적용 패턴 출력, 패턴 알림,삭제 api 연동

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39

## ⏳ 작업 내용
- 적용 패턴 출력
- 패턴 알림 api 연동
- 패턴 삭제 api 연동

## 📸 스크린샷

https://github.com/user-attachments/assets/2e65b85a-b04f-49e8-926e-f27f47dadd56



## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- pull 받고 보니 mypage_screen에 누락된 코드 부분이 있어서 원래 코드 참고해서 추가한 뒤 commit 했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 패턴 알림 토글 버튼 추가(패턴 적용 시 사용 가능), 상태 스낵바 제공
  - 관심 패턴에서 패턴 삭제 기능(확인 다이얼로그, 성공/실패 알림)
  - 패턴 차트에 허용 오차 밴드 및 패딩 옵션 추가, 데이터 없음 플레이스홀더 개선
- Style
  - 주요 액션 버튼을 일관된 ElevatedButton 스타일로 변경
  - 레이아웃 정리: 헤더+알림 버튼 분리, 차트 섹션 분리, 항상 스크롤 가능 처리
  - AppBar 배경색을 흰색으로 변경
  - 워치리스트에서 기존 알림 아이콘 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->