### PR TITLE
[FEAT] 감정투자일기 페이지 구현 및 api 연동

### DIFF
--- a/lib/data/emotion_diary_api.dart
+++ b/lib/data/emotion_diary_api.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+
+class EmotionDiaryApi {
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://pattern-catcher.net:8080', // ✅ 실제 baseURL
+      headers: {'Content-Type': 'application/json'},
+    ),
+  );
+
+  /// 요청
+  Future<Map<String, dynamic>> postDiary(String content) async {
+    try {
+      final response = await _dio.post('/diaries', data: {
+        'content': content,
+      });
+
+      return response.data['result']; // ✅ 감정 분석 결과 리턴
+    } catch (e) {
+      print('❌ 요청 실패: $e');
+      rethrow;
+    }
+  }
+
+  /// 목록
+  Future<List<Map<String, dynamic>>> fetchDiaries() async {
+    try {
+      final response = await _dio.get('/diaries');
+      return List<Map<String, dynamic>>.from(response.data['result']);
+    } catch (e) {
+      print('❌ 일기 목록 불러오기 실패: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:stockapp/screens/login_screen.dart';
 import 'package:stockapp/services/push_notification_service.dart';
 
@@ -13,6 +14,7 @@ void main() async {
 
   await PushNotificationService.initialize();
 
+  await initializeDateFormatting('ko', null);
   runApp(const MyApp());
 }
 

--- a/lib/routes/TabView.dart
+++ b/lib/routes/TabView.dart
@@ -19,7 +19,7 @@ class _TabviewState extends State<Tabview> {
     MainScreen(),
     InterestScreen(),
     ChartScreen(),
-    DairyScreen(),
+    DiaryScreen(),
     MypageScreen(),
   ];
 

--- a/lib/screens/diary_screen.dart
+++ b/lib/screens/diary_screen.dart
@@ -1,11 +1,53 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:stockapp/data/emotion_diary_api.dart';
 import 'package:stockapp/widgets/emotion_diary/DairyBubble.dart';
 import 'package:stockapp/widgets/emotion_diary/EmotionAnalysisCard.dart';
 import 'package:stockapp/widgets/emotion_diary/EmotionHeader.dart';
 import 'package:stockapp/widgets/emotion_diary/EmotionInputBar.dart';
 
-class DairyScreen extends StatelessWidget {
-  const DairyScreen({super.key});
+class DiaryScreen extends StatefulWidget {
+  const DiaryScreen({super.key});
+
+  @override
+  State<DiaryScreen> createState() => _DiaryScreenState();
+}
+
+class _DiaryScreenState extends State<DiaryScreen> {
+  final EmotionDiaryApi _api = EmotionDiaryApi();
+
+  List<Map<String, dynamic>> _diaryList = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDiaries();
+  }
+
+  Future<void> _loadDiaries() async {
+    final result = await _api.fetchDiaries();
+    setState(() {
+      _diaryList = result.toList(); // 최신순
+    });
+  }
+
+  Future<void> _submitDiary(Map<String, dynamic> result) async {
+    await _loadDiaries(); // 새 일기 등록 후 목록 갱신
+  }
+
+  //날짜 포멧
+  String formatDate(dynamic createdAt) {
+    try {
+      final String isoString = createdAt.toString();
+      final trimmed = isoString.split('.').first;
+      final date = DateTime.parse(trimmed);
+      return DateFormat('yyyy년 M월 d일', 'ko').format(date);
+    } catch (e) {
+      print('날짜 포맷팅 실패: $e');
+      return '날짜 없음';
+    }
+  }
+
 
   @override
   Widget build(BuildContext context) {
@@ -17,23 +59,38 @@ class DairyScreen extends StatelessWidget {
             const EmotionHeader(),
             const SizedBox(height: 12),
             Expanded(
-              child: ListView(
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-                children: const [
-                  SizedBox(height: 12),
-                  DiaryBubble(
-                    text:
-                    '오늘 삼성전자 주식을 매도했는데 내가 사고 나서 떡락해서 진짜 너무 화난다 ㅡㅡ',
-                  ),
-                  SizedBox(height: 12),
-                  EmotionAnalysisCard(),
-                  SizedBox(height: 20),
-                ],
+              child: ListView.builder(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                itemCount: _diaryList.length,
+                itemBuilder: (context, index) {
+                  final diary = _diaryList[index];
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 12),
+                      Center(
+                        child: Text(
+                          formatDate(diary['createdAt']),
+                          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      DiaryBubble(text: diary['content'] ?? ''),
+                      const SizedBox(height: 8),
+                      EmotionAnalysisCard(
+                        emotions: List<String>.from(diary['emotion'] ?? []),
+                        summary: diary['summary'] ?? '',
+                        feedback: diary['feedback'] ?? '',
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                  );
+                },
               ),
             ),
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16),
-              child: EmotionInputBar(),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: EmotionInputBar(onSubmit: _submitDiary),
             ),
             const SizedBox(height: 12),
           ],
@@ -42,3 +99,4 @@ class DairyScreen extends StatelessWidget {
     );
   }
 }
+

--- a/lib/screens/diary_screen.dart
+++ b/lib/screens/diary_screen.dart
@@ -15,6 +15,7 @@ class DiaryScreen extends StatefulWidget {
 
 class _DiaryScreenState extends State<DiaryScreen> {
   final EmotionDiaryApi _api = EmotionDiaryApi();
+  final ScrollController _scrollController = ScrollController();
 
   List<Map<String, dynamic>> _diaryList = [];
 
@@ -24,18 +25,31 @@ class _DiaryScreenState extends State<DiaryScreen> {
     _loadDiaries();
   }
 
-  Future<void> _loadDiaries() async {
-    final result = await _api.fetchDiaries();
-    setState(() {
-      _diaryList = result.toList(); // 최신순
+  // 데이터 로드 후 맨 아래로 이동
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
     });
   }
 
-  Future<void> _submitDiary(Map<String, dynamic> result) async {
-    await _loadDiaries(); // 새 일기 등록 후 목록 갱신
+  Future<void> _loadDiaries() async {
+    final result = await _api.fetchDiaries();
+    setState(() {
+      _diaryList = result.toList();
+    });
+    _scrollToBottom();
   }
 
-  //날짜 포멧
+  Future<void> _submitDiary(Map<String, dynamic> result) async {
+    await _loadDiaries();
+  }
+
   String formatDate(dynamic createdAt) {
     try {
       final String isoString = createdAt.toString();
@@ -48,10 +62,64 @@ class _DiaryScreenState extends State<DiaryScreen> {
     }
   }
 
+  Map<String, List<Map<String, dynamic>>> groupDiariesByDate(List<Map<String, dynamic>> diaries) {
+    final Map<String, List<Map<String, dynamic>>> grouped = {};
+
+    for (final diary in diaries) {
+      final createdAt = diary['createdAt'];
+      if (createdAt == null) continue;
+
+      final dateKey = createdAt.toString().substring(0, 10);
+      grouped.putIfAbsent(dateKey, () => []);
+      grouped[dateKey]!.add(diary);
+    }
+
+    return grouped;
+  }
+
+  List<Widget> _buildGroupedDiaryWidgets() {
+    final grouped = groupDiariesByDate(_diaryList);
+    final sortedDateKeys = grouped.keys.toList()..sort((a, b) => a.compareTo(b));
+
+    final List<Widget> widgets = [];
+
+    for (final dateKey in sortedDateKeys) {
+      final dateFormatted = formatDate(dateKey);
+
+      widgets.add(
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: Center(
+            child: Text(
+              dateFormatted,
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+            ),
+          ),
+        ),
+      );
+
+      for (final diary in grouped[dateKey]!) {
+        widgets.addAll([
+          const SizedBox(height: 6),
+          DiaryBubble(text: diary['content'] ?? ''),
+          const SizedBox(height: 8),
+          EmotionAnalysisCard(
+            emotions: List<String>.from(diary['emotion'] ?? []),
+            summary: diary['summary'] ?? '',
+            feedback: diary['feedback'] ?? '',
+          ),
+          const SizedBox(height: 16),
+        ]);
+      }
+    }
+
+    return widgets;
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: true,
       backgroundColor: Colors.white,
       body: SafeArea(
         child: Column(
@@ -59,33 +127,10 @@ class _DiaryScreenState extends State<DiaryScreen> {
             const EmotionHeader(),
             const SizedBox(height: 12),
             Expanded(
-              child: ListView.builder(
+              child: ListView(
+                controller: _scrollController, //페이지 진입 시 맨 아래로 이동
                 padding: const EdgeInsets.symmetric(horizontal: 20),
-                itemCount: _diaryList.length,
-                itemBuilder: (context, index) {
-                  final diary = _diaryList[index];
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const SizedBox(height: 12),
-                      Center(
-                        child: Text(
-                          formatDate(diary['createdAt']),
-                          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
-                        ),
-                      ),
-                      const SizedBox(height: 6),
-                      DiaryBubble(text: diary['content'] ?? ''),
-                      const SizedBox(height: 8),
-                      EmotionAnalysisCard(
-                        emotions: List<String>.from(diary['emotion'] ?? []),
-                        summary: diary['summary'] ?? '',
-                        feedback: diary['feedback'] ?? '',
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                  );
-                },
+                children: _buildGroupedDiaryWidgets(),
               ),
             ),
             Padding(
@@ -99,4 +144,3 @@ class _DiaryScreenState extends State<DiaryScreen> {
     );
   }
 }
-

--- a/lib/widgets/emotion_diary/EmotionAnalysisCard.dart
+++ b/lib/widgets/emotion_diary/EmotionAnalysisCard.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart';
 
 class EmotionAnalysisCard extends StatelessWidget {
-  const EmotionAnalysisCard({super.key});
+  final List<String> emotions;
+  final String summary;
+  final String feedback;
+
+  const EmotionAnalysisCard({
+    super.key,
+    required this.emotions,
+    required this.summary,
+    required this.feedback,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -16,10 +25,28 @@ class EmotionAnalysisCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(8),
           ),
           child:
-              Text(
-                  style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 12),
-                  '감정 분석: 후회, 분노, 실망 \n투자 조언: 감정이 격한 날은 매매를 자제하는 것도 전략입니다. \n오늘의 일기: 삼성전자 매도 후 하락으로 큰 분노. 감정적 결정에 대해 되돌아보는 하루.'
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.sentiment_satisfied_alt, color: Colors.orange),
+                  const SizedBox(width: 8),
+                  Expanded( // ✅ 요거 추가!
+                    child: Text(
+                      '감정 분석: ${emotions.join(", ")}',
+                      softWrap: true,
+                      overflow: TextOverflow.visible,
+                    ),
+                  ),
+                ],
               ),
+              const SizedBox(height: 10),
+              Text('💡 투자 조언: $feedback'),
+              const SizedBox(height: 10),
+              Text('📝 오늘의 일기: $summary'),
+            ],
+          ),
           ),
         ),
       );

--- a/lib/widgets/emotion_diary/EmotionAnalysisCard.dart
+++ b/lib/widgets/emotion_diary/EmotionAnalysisCard.dart
@@ -32,7 +32,7 @@ class EmotionAnalysisCard extends StatelessWidget {
                 children: [
                   const Icon(Icons.sentiment_satisfied_alt, color: Colors.orange),
                   const SizedBox(width: 8),
-                  Expanded( // ✅ 요거 추가!
+                  Expanded(
                     child: Text(
                       '감정 분석: ${emotions.join(", ")}',
                       softWrap: true,

--- a/lib/widgets/emotion_diary/EmotionHeader.dart
+++ b/lib/widgets/emotion_diary/EmotionHeader.dart
@@ -7,15 +7,15 @@ class EmotionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: const [
+        SizedBox(height: 10),
         Text('ai 감정 투자 일기', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
         SizedBox(height: 4),
         Text(
-          '~~~감정 투자일기에 관한\n간단한 설명~~~',
+          '입력한 투자 일기를 AI가 감정 분석하여\n감정 상태와 투자 조언을 제공해드립니다.',
           textAlign: TextAlign.center,
           style: TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
         ),
         SizedBox(height: 6,),
-        Text('2025년 8월 3일', style: TextStyle(fontWeight: FontWeight.w600, fontSize: 12),)
       ],
     );
   }

--- a/lib/widgets/emotion_diary/EmotionInputBar.dart
+++ b/lib/widgets/emotion_diary/EmotionInputBar.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:stockapp/data/emotion_diary_api.dart';
 
 class EmotionInputBar extends StatefulWidget {
-  const EmotionInputBar({super.key});
+  final Function(Map<String, dynamic>) onSubmit; // ✅ 추가: 결과 전달 콜백
+
+  const EmotionInputBar({super.key, required this.onSubmit});
 
   @override
   State<EmotionInputBar> createState() => _EmotionInputBarState();
@@ -9,13 +12,21 @@ class EmotionInputBar extends StatefulWidget {
 
 class _EmotionInputBarState extends State<EmotionInputBar> {
   final TextEditingController _controller = TextEditingController();
+  final EmotionDiaryApi _api = EmotionDiaryApi();
 
-  void _handleSend() {
+  Future<void> _handleSend() async {
     final text = _controller.text.trim();
-    if (text.isNotEmpty) {
-      // 여기에 전송 로직 추가 (예: print, 서버 전송 등)
-      print("✉️ 감정 일기 전송: $text");
+    if (text.isEmpty) return;
+
+    try {
+      final result = await _api.postDiary(text); // 감정 분석 결과 받기
+
+      widget.onSubmit(result); // 부모에게 결과 전달
+
+      print('✅ 감정 일기 전송 완료'); // 콘솔 출력
       _controller.clear();
+    } catch (e) {
+      print('❌ 감정 일기 전송 실패: $e'); // 실패 로그만 출력
     }
   }
 
@@ -29,7 +40,7 @@ class _EmotionInputBarState extends State<EmotionInputBar> {
         decoration: InputDecoration(
           hintText: '오늘 투자하며 느낀 감정을 자유롭게 적어보세요.',
           filled: true,
-          fillColor: Color(0xFFF2F2F2),
+          fillColor: const Color(0xFFF2F2F2),
           contentPadding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
           suffixIcon: IconButton(
             icon: const Icon(Icons.send),

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/common/InfoCardGroup.dart';
+import 'dart:math' as math;
 
 class BacktestResultCard extends StatelessWidget {
   final BacktestResult result;
   const BacktestResultCard({required this.result});
 
-  String _fmtPct(num v, {bool isRatio = false}) {
-    final p = isRatio ? v * 100 : v;
-    return '${p.toStringAsFixed(2)}%';
+  double _truncate(num v, int decimals) {
+    final f = math.pow(10, decimals).toDouble();
+    return (v * f).truncateToDouble() / f; // 소수점 2자리까지 출력
+  }
+
+  String _fmtPct(
+      num v, {
+        bool inputIsRatio = false, // true면 0.053 -> 5.3%
+        int decimals = 2,
+        bool round = true,    // false면 반올림 안 하고 자리수에서 자름(내림/절삭)
+      }) {
+    final p = (inputIsRatio ? v * 100 : v.toDouble());
+    final d = round ? double.parse(p.toStringAsFixed(decimals))
+        : _truncate(p, decimals);
+    return '${d.toStringAsFixed(decimals)}%';
   }
 
   @override
@@ -33,9 +46,9 @@ class BacktestResultCard extends StatelessWidget {
               // 지표들
               InfoCardGroup(
                 rows: [
-                  {'label': '승률', 'value': _fmtPct(result.winRate)},
-                  {'label': '평균 수익', 'value': _fmtPct(result.averageReturn, isRatio: true), 'color': const Color(0xFF289BF6)},
-                  {'label': '최대 수익', 'value': _fmtPct(result.maxReturn), 'subValue': result.maxReturnDate,'color': const Color(0xFF289BF6)},
+                  {'label': '승률', 'value': _fmtPct(result.winRate, decimals: 1)},
+                  {'label': '평균 수익', 'value': _fmtPct(result.averageReturn, decimals: 2, inputIsRatio: false), 'color': const Color(0xFF289BF6)},
+                  {'label': '최대 수익', 'value': _fmtPct(result.maxReturn,   decimals: 2, round: false), 'subValue': result.maxReturnDate,'color': const Color(0xFF289BF6)},
                 ],),
 
               const SizedBox(height: 12),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -372,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
감정 일기 페이지 구현 및 api 연동

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #28 

## ⏳ 작업 내용
- 감정투자일기 목록 api 연동
- 감정투자일기 작성 api 연동
- 화면 스크롤이 맨 아래가 디폴트 이도록 수정
- 백테스팅 결과 소수점 알맞게 수정

## 📸 스크린샷
<img width="490" height="203" alt="image" src="https://github.com/user-attachments/assets/812e0293-7c90-4b73-b19b-92cb39acf22a" />



https://github.com/user-attachments/assets/8d8466f8-2c3b-42d2-9540-b0e8466d9173




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 감정 투자 일기 기능 추가: 일기 작성/조회, AI 감정 분석 카드 표시, 날짜별 그룹화, 입력 후 자동 새로고침.
  - 한국어 날짜 포맷 지원으로 로컬라이즈된 날짜 표시.
- Bug Fixes
  - 탭에서 올바른 일기 화면이 표시되도록 수정.
- Style
  - 헤더 문구 및 상단 여백 개선, 정적 날짜 제거.
  - 승률/수익률 지표의 표시 자리수와 반올림/버림 규칙 정교화로 가독성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->