### PR TITLE
[REFACTOR] 메인,검색 페이지 수정

### DIFF
--- a/lib/screens/chart_detail_screen.dart
+++ b/lib/screens/chart_detail_screen.dart
@@ -397,24 +397,22 @@ class _PatternDetailPageState extends State<PatternDetailPage> {
                         await _fetchPatternDetail(); // 수정 후 새로고침
                         return _pattern!.toJson();
                       },
-
                     ),
-                    child: const Text("종목 바꾸기"),
                   )
-                ],
-              ),
+              );
 
-              const SizedBox(height: 16),
+              const SizedBox(height: 16);
 
-              SizedBox(
-                height: 200,
-                child: InteractiveChart(
-                  candles: candles,
-                  style: const ChartStyle(
-                    priceGainColor: Colors.red,
-                    priceLossColor: Colors.blue,
-                  ),
-                );
+              // SizedBox(
+              //   height: 200,
+              //   child: InteractiveChart(
+              //     candles: candles,
+              //     style: const ChartStyle(
+              //       priceGainColor: Colors.red,
+              //       priceLossColor: Colors.blue,
+              //     ),
+              //   ),
+              // );
 
                 if (updated != null) {
                   setState(() => _pattern = PatternDetail.fromJson(updated));

--- a/lib/widgets/interest/pattern_empty_view.dart
+++ b/lib/widgets/interest/pattern_empty_view.dart
@@ -17,9 +17,18 @@ class PatternEmptyView extends StatelessWidget {
             children: [
               const Text('설정된 차트 패턴이 없습니다.'),
               const SizedBox(height: 10),
-              FilledButton(
+              ElevatedButton(
                 onPressed: () {/* 패턴 추가 화면 이동 */},
-                child: const Text('패턴 추가하기'),
+                style: ElevatedButton.styleFrom(
+                  foregroundColor: Colors.white,
+                  backgroundColor: Colors.black,
+                  textStyle: TextStyle(fontWeight: FontWeight.w500, fontSize: 12),
+                  padding: EdgeInsets.all(12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: Text('패턴 추가하기'),
               ),
             ],
           ),

--- a/lib/widgets/main/RecentStockList.dart
+++ b/lib/widgets/main/RecentStockList.dart
@@ -1,50 +1,93 @@
 import 'package:flutter/material.dart';
-import 'package:stockapp/widgets/common/RecentStocks.dart';
-import 'package:stockapp/widgets/main/StockItems.dart';
+import 'package:stockapp/data/recent_api.dart';
+import 'package:stockapp/models/stock_brief.dart';
+import 'package:stockapp/widgets/main/recent_stock_tile.dart';
 
-// 최근 조회 종목 리스트 카드
-class RecentStockList extends StatelessWidget {
+class RecentStockList extends StatefulWidget {
   const RecentStockList({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final recent = RecentStocks.recent;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Padding(
-          padding: EdgeInsets.only(left: 16, right: 16, bottom: 8),
-          child: Text('최근 조회 종목', style: TextStyles.title),
-        ),
-
-        if (recent.isEmpty)
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-            child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text('최근 조회한 종목이 없습니다.', style: TextStyles.content)),
-          )
-        else
-          ...recent.map((stock) => Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4),
-            child: StockItems(stock: stock),
-          )),
-      ],
-    );
-  }
+  State<RecentStockList> createState() => _RecentStockListState();
 }
 
+class _RecentStockListState extends State<RecentStockList> {
+  final _api = RecentApi();
+  late Future<List<StockBrief>> _future;
 
-// styles
-class TextStyles {
-  static const TextStyle title = TextStyle(
-    fontWeight: FontWeight.w700,
-    fontSize: 20,
-  );
+  @override
+  void initState() {
+    super.initState();
+    _future = _api.fetchRecent();
+  }
 
-  static const TextStyle content = TextStyle(
-    fontWeight: FontWeight.w600,
-    color: Color(0xFFAEAEAE),
-  );
+  Future<void> _reload() async {
+    setState(() => _future = _api.fetchRecent());
+    await _future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<StockBrief>>(
+      future: _future,
+      builder: (context, snap) {
+        if (snap.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: SizedBox(height: 56, child: Center(child: CircularProgressIndicator())),
+          );
+        }
+        if (snap.hasError) {
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextButton.icon(
+              onPressed: _reload,
+              icon: const Icon(Icons.refresh),
+              label: Text('최근 조회 종목을 불러오지 못했습니다: ${snap.error}'),
+            ),
+          );
+        }
+
+        // 전체 결과에서 최신순 3개만 사용 (API가 최신순으로 내려준다는 가정)
+        final all = snap.data ?? const <StockBrief>[];
+        final items = all.take(3).toList(); // ← 여기!
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.only(left: 16, right: 16, bottom: 8),
+              child: Text('최근 조회 종목',
+                  style: TextStyle(fontWeight: FontWeight.w700, fontSize: 20)),
+            ),
+            if (items.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text('최근 조회한 종목이 없습니다.',
+                      style: TextStyle(fontWeight: FontWeight.w600, color: Color(0xFFAEAEAE))),
+                ),
+              )
+            else
+              ...List.generate(items.length, (i) {
+                final s = items[i];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
+                  child: Column(
+                    children: [
+                      RecentStockTile(
+                        stock: s,
+                        onTap: () {
+                          // TODO: 상세 이동
+                        },
+                      ),
+                    ],
+                  ),
+                );
+              }),
+          ],
+        );
+      },
+    );
+  }
 }

--- a/lib/widgets/main/TopStockListCard.dart
+++ b/lib/widgets/main/TopStockListCard.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:stockapp/screens/stock_detail_screen.dart';
 import 'package:stockapp/screens/topStock_screen.dart';
@@ -32,7 +34,7 @@ class TopStockListCard extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('10시 기준', style: TextStyles.timeText),
+                  HourBasisText(style: TextStyles.timeText),
 
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 5),
@@ -96,6 +98,7 @@ class TopStockListCard extends StatelessWidget {
   }
 }
 
+//현재시간 업데이트
 class TextStyles {
   static const TextStyle timeText = TextStyle(
     fontSize: 14,
@@ -109,4 +112,49 @@ class TextStyles {
   );
 
   static const TextStyle buttonText = TextStyle(fontWeight: FontWeight.w700);
+}
+
+
+class HourBasisText extends StatefulWidget {
+  final TextStyle? style;
+  const HourBasisText({super.key, this.style});
+
+  @override
+  State<HourBasisText> createState() => _HourBasisTextState();
+}
+
+class _HourBasisTextState extends State<HourBasisText> {
+  Timer? _timer;
+  late String _label;
+
+  void _update() {
+    final now = DateTime.now();
+    _label = '${now.hour}시 기준'; // 8:56 -> 8시 기준, 16:45 -> 16시 기준
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _update();
+    // 다음 분 경계에 맞춰 1분마다 업데이트
+    final now = DateTime.now();
+    final toNextMinute = Duration(minutes: 1)
+        - Duration(seconds: now.second, milliseconds: now.millisecond);
+    _timer = Timer(toNextMinute, () {
+      _update();
+      _timer = Timer.periodic(const Duration(minutes: 1), (_) => _update());
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(_label, style: widget.style);
+  }
 }

--- a/lib/widgets/main/recent_stock_tile.dart
+++ b/lib/widgets/main/recent_stock_tile.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/models/stock_brief.dart';
+
+class RecentStockTile extends StatelessWidget {
+  final StockBrief stock;
+  final VoidCallback? onTap;
+  const RecentStockTile({super.key, required this.stock, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Row(
+        children: [
+          ClipOval(
+            child: Image.network(
+              stock.imageUrl,
+              width: 40, height: 40, fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => CircleAvatar(
+                radius: 20, backgroundColor: const Color(0xFFF1F3F5),
+                child: Text(stock.name.isNotEmpty ? stock.name.characters.first : '?'),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              stock.name,
+              style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/search/SearchStockItem.dart
+++ b/lib/widgets/search/SearchStockItem.dart
@@ -14,7 +14,14 @@ class SearchStockItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: Image.network(stock.imageUrl, width: 30, height: 30),
+      leading: ClipOval(
+        child: Image.network(
+          stock.imageUrl, // 주식 이미지 url
+          width: 40,
+          height: 40,
+          fit: BoxFit.cover,
+        ),
+      ),
       title: Text(stock.name, style: TextStyle(fontWeight: FontWeight.w600),),
       onTap: onTap,
     );


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
메인,검색 페이지 개선

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #51 

## ⏳ 작업 내용
- 메인 페이지 시간
- 메인 페이지 최근 조회 종목 api 연동
- 검색 페이지 이미지 원으로 수정

## 📸 스크린샷
<img width="450" height="889" alt="image" src="https://github.com/user-attachments/assets/c3759bc8-ec4a-4036-a399-98ed3b3d2071" />
<img width="439" height="473" alt="image" src="https://github.com/user-attachments/assets/ec91ccd5-0456-475b-a0de-d9b4d7b16d0e" />
<img width="420" height="353" alt="image" src="https://github.com/user-attachments/assets/5eefa0a9-f285-4f6e-9e35-1b43d9870d10" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 현재 시 기준 라벨이 자동으로 갱신되는 시간 표시 추가.
- 리팩터링
  - 최근 본 종목 리스트가 비동기 로딩, 에러 처리, 새로고침을 지원하도록 개선.
  - 패턴 편집 화면에서 인라인 차트와 ‘종목 바꾸기’ 버튼 제거, 편집 후 상태 반영 로직 단순화.
- 스타일
  - 패턴 비어 있음 화면의 버튼을 검은 배경/흰 글자의 ElevatedButton으로 변경.
  - 검색 및 목록의 종목 이미지를 원형 아바타로 표시.
  - 최근 종목 타일 컴포넌트로 목록 시각 일관성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->