### PR TITLE
Feat/51/backtest list

### DIFF
--- a/lib/data/back_candle_api.dart
+++ b/lib/data/back_candle_api.dart
@@ -1,0 +1,44 @@
+// backtest_candle_api.dart
+import 'package:dio/dio.dart';
+import 'package:interactive_chart/interactive_chart.dart';
+import '../models/CandelChartModel.dart';
+
+final Dio _dio = Dio();
+
+
+Future<List<CandleData>> fetchBacktestCandles({
+  required int backtestId,
+  required String stockId,
+  String interval = '1D',
+  String? startDate,
+  String? endDate,
+}) async {
+  // 백테스트 차트 구간을 지정하기 위한 쿼리 파라미터 구성
+  final query = {
+    'stockId': stockId,
+    'interval': interval,
+    if (startDate != null && startDate.isNotEmpty) 'startDate': startDate,
+    if (endDate != null && endDate.isNotEmpty) 'endDate': endDate,
+  };
+  final params = query.entries.map((e) => '${e.key}=${Uri.encodeComponent(e.value)}').join('&');
+  final url = 'http://52.79.115.136:8080/backtests/results/$backtestId/candles?$params';
+
+  try {
+    final response = await _dio.get(url);
+
+    if (response.statusCode == 200) {
+      final data = response.data;
+      final List result = (data['result'] as List? ?? const []);
+      return result
+          .map((e) => CandleApiResponse.fromJson(e).toCandleData())
+          .toList();
+    } else {
+      throw Exception("백테스트 캔들 데이터 불러오기 실패: ${response.statusCode}");
+    }
+  } catch (e) {
+    // 디버깅 편의를 위해 에러 출력
+    // ignore: avoid_print
+    print("❌ Dio 요청 에러: $e");
+    throw Exception("네트워크 오류 또는 서버 오류 발생");
+  }
+}

--- a/lib/data/backtest_api.dart
+++ b/lib/data/backtest_api.dart
@@ -10,6 +10,23 @@ class BacktestService {
     ),
   );
 
+  /// periodUnit → interval 매핑 유틸
+  /// 서버가 "HOUR"/"DAY" 등을 주면 캔들 조회 interval로 변환해 사용할 수 있음.
+  static String intervalFromPeriodUnit(String? periodUnit) {
+    switch ((periodUnit ?? '').toUpperCase()) {
+      case 'MINUTE':
+      case 'MIN':
+        return '1m';
+      case 'HOUR':
+      case 'H':
+        return '1H';
+      case 'DAY':
+      case 'D':
+      default:
+        return '1D';
+    }
+  }
+
   static Future<List<Map<String, dynamic>>> fetchBacktestList({int? patternId}) async {
     try {
       final res = await _dio.get(
@@ -19,9 +36,19 @@ class BacktestService {
       final data = res.data;
       final list = List<Map<String, dynamic>>.from(data['result']['content']);
 
+      // 편의 필드 보정
       for (final m in list) {
-        if (m['stockId'] == null && m['stock'] is Map && (m['stock']['id'] is num)) {
-          m['stockId'] = (m['stock']['id'] as num).toInt();
+        final stock = m['stock'];
+        if (stock is Map) {
+          if (m['stockId'] == null && stock['id'] is num) {
+            m['stockId'] = (stock['id'] as num).toInt();
+          }
+          if (m['stockName'] == null && stock['name'] != null) {
+            m['stockName'] = stock['name'].toString();
+          }
+          if (m['stockImage'] == null && stock['imageUrl'] != null) {
+            m['stockImage'] = stock['imageUrl'].toString();
+          }
         }
       }
       return list;
@@ -30,20 +57,30 @@ class BacktestService {
     }
   }
 
-
   static Future<Map<String, dynamic>> fetchBacktestResult(
       int backtestId, {
         int? stockId,
       }) async {
     try {
-      final res = await _dio.get('/backtests/results/$backtestId');
+      final res = await _dio.get(
+        '/backtests/results/$backtestId',
+        queryParameters: stockId == null ? null : {'stockId': stockId},
+      );
       final map = Map<String, dynamic>.from(res.data['result']);
 
+      // stock 정보에서 파생 필드 보정
       if (map['stockId'] == null && map['stock'] is Map && (map['stock']['id'] is num)) {
         map['stockId'] = (map['stock']['id'] as num).toInt();
       }
       map['stockId'] ??= stockId;
+      if (map['stockName'] == null && map['stock'] is Map && map['stock']['name'] != null) {
+        map['stockName'] = map['stock']['name'].toString();
+      }
+      if (map['stockImage'] == null && map['stock'] is Map && map['stock']['imageUrl'] != null) {
+        map['stockImage'] = map['stock']['imageUrl'].toString();
+      }
 
+      // highlightRange/periodUnit는 그대로 전달(모델에서 파싱)
       return map;
     } catch (e) {
       throw Exception('백테스트 상세 조회 실패: $e');

--- a/lib/models/backtest_result.dart
+++ b/lib/models/backtest_result.dart
@@ -15,7 +15,7 @@ class StockResult {
     return StockResult(
       id: (json['id'] as num).toInt(),
       name: (json['name'] ?? '').toString(),
-      imageUrl: (json['imageUrl'] ?? '').toString(),
+      imageUrl: (json['imageUrl'] ?? json['stockImage'] ?? '').toString(),
     );
   }
 
@@ -28,10 +28,37 @@ class StockResult {
   }
 }
 
+/// 하이라이트 범위 모델
+class HighlightRange {
+  final DateTime? fromDate;
+  final DateTime? toDate;
+
+  const HighlightRange({this.fromDate, this.toDate});
+
+  factory HighlightRange.fromJson(Map<String, dynamic>? json) {
+    if (json == null) return const HighlightRange();
+    DateTime? parse(String? s) {
+      if (s == null || s.isEmpty) return null;
+      // ISO-8601(yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss) 모두 대응
+      return DateTime.tryParse(s);
+    }
+
+    return HighlightRange(
+      fromDate: parse(json['fromDate']?.toString()),
+      toDate: parse(json['toDate']?.toString()),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'fromDate': fromDate?.toIso8601String(),
+    'toDate': toDate?.toIso8601String(),
+  };
+}
+
 /// 백테스트 결과 모델
 class BacktestResult {
   final int? backtestId;
-  final List<StockResult> stockResults; // ✅ lowerCamelCase
+  final List<StockResult> stockResults;
   final String executedAt;
   final String startDate;
   final String endDate;
@@ -46,10 +73,12 @@ class BacktestResult {
   final String lastMatchedDate;
   final double lastMatchedReturn;
   final double? targetReturn;
+  final HighlightRange? highlightRange;
+  final String? periodUnit; // "HOUR" | "DAY" | "MINUTE" 등 서버 스펙
 
   BacktestResult({
     this.backtestId,
-    required this.stockResults, // ✅ lowerCamelCase
+    required this.stockResults,
     required this.executedAt,
     required this.startDate,
     required this.endDate,
@@ -64,11 +93,13 @@ class BacktestResult {
     required this.lastMatchedDate,
     required this.lastMatchedReturn,
     this.targetReturn,
+    this.highlightRange,
+    this.periodUnit,
   });
 
-  /// JSON -> 모델 변환
+  /// JSON -> 모델 변환 (신/구 키 혼용 대응)
   factory BacktestResult.fromJson(Map<String, dynamic> json) {
-    // 새 키(소문자) 우선, 구버전 대소문자 키 하위호환
+    // stockResults 배열(신규) 또는 단일 객체(구버전) 대응
     final rawList = json['stockResults'] ?? json['StockResults'];
     List<StockResult> stocks;
     if (rawList is List) {
@@ -83,33 +114,52 @@ class BacktestResult {
         ),
       ];
     } else if (json['StockResult'] is Map) {
-      // 구버전 단일 키도 지원
       stocks = [
         StockResult.fromJson(
           Map<String, dynamic>.from(json['StockResult'] as Map),
         ),
       ];
+    } else if (json['stock'] is Map) {
+      // 서버가 stock 단일 객체만 주는 경우도 일부 고려
+      final m = Map<String, dynamic>.from(json['stock'] as Map);
+      stocks = [
+        StockResult.fromJson({
+          'id': m['id'],
+          'name': m['name'],
+          'imageUrl': m['imageUrl'] ?? m['stockImage'],
+        })
+      ];
     } else {
       stocks = const [];
     }
+
+    // 숫자 안전 파싱
+    double d(dynamic v) => (v is num) ? v.toDouble() : double.tryParse('$v') ?? 0.0;
+    int i(dynamic v) => (v is num) ? v.toInt() : int.tryParse('$v') ?? 0;
 
     return BacktestResult(
       backtestId: (json['backtestId'] as num?)?.toInt(),
       executedAt: (json['executedAt'] ?? json['createdAt'] ?? '').toString(),
       startDate: (json['startDate'] ?? '').toString(),
       endDate: (json['endDate'] ?? '').toString(),
-      matchedCount: (json['matchedCount'] as num?)?.toInt() ?? 0,
-      winRate: (json['winRate'] as num?)?.toDouble() ?? 0,
-      averageReturn: (json['averageReturn'] as num?)?.toDouble() ?? 0,
-      maxReturn: (json['maxReturn'] as num?)?.toDouble() ?? 0,
+      matchedCount: i(json['matchedCount']),
+      winRate: d(json['winRate']),
+      averageReturn: d(json['averageReturn']),
+      maxReturn: d(json['maxReturn']),
       maxReturnDate: (json['maxReturnDate'] ?? '').toString(),
-      minReturn: (json['minReturn'] as num?)?.toDouble() ?? 0,
+      minReturn: d(json['minReturn']),
       minReturnDate: (json['minReturnDate'] ?? '').toString(),
-      totalReturn: (json['totalReturn'] as num?)?.toDouble() ?? 0,
+      totalReturn: d(json['totalReturn']),
       lastMatchedDate: (json['lastMatchedDate'] ?? '').toString(),
-      lastMatchedReturn: (json['lastMatchedReturn'] as num?)?.toDouble() ?? 0,
-      targetReturn: (json['targetReturn'] as num?)?.toDouble(),
-      stockResults: stocks, // ✅ 리스트를 그대로 대입 (중첩 X)
+      lastMatchedReturn: d(json['lastMatchedReturn']),
+      targetReturn: (json['targetReturn'] is num)
+          ? (json['targetReturn'] as num).toDouble()
+          : double.tryParse('${json['targetReturn']}'),
+      stockResults: stocks,
+      highlightRange: HighlightRange.fromJson(
+        (json['highlightRange'] is Map) ? Map<String, dynamic>.from(json['highlightRange']) : null,
+      ),
+      periodUnit: (json['periodUnit'] ?? json['PeriodUnit'])?.toString(),
     );
   }
 
@@ -130,6 +180,8 @@ class BacktestResult {
     'lastMatchedDate': lastMatchedDate,
     'lastMatchedReturn': lastMatchedReturn,
     'targetReturn': targetReturn,
-    'stockResults': stockResults.map((e) => e.toJson()).toList(), // ✅ 소문자 키
+    'stockResults': stockResults.map((e) => e.toJson()).toList(),
+    'highlightRange': highlightRange?.toJson(),
+    'periodUnit': periodUnit,
   };
 }

--- a/lib/models/pattern.dart
+++ b/lib/models/pattern.dart
@@ -124,6 +124,9 @@ class PatternDetail {
         .map((e) => (e as num).toInt())
         .toList();
 
+    // 서버에서 내려온 패턴 적용 종목 정보를 파싱한다.
+    // 기존에는 name 정도만 사용했지만, 상세 화면 이동을 위해
+    // stockId, symbol, stockName, stockImage 까지 모두 보존한다.
     final stocksRaw = json['appliedStockList'];
     final List<Map<String, dynamic>> stocks = [];
     if (stocksRaw is List) {
@@ -131,13 +134,27 @@ class PatternDetail {
         if (e is Map) {
           final m = Map<String, dynamic>.from(e as Map);
           final id = m['stockId'] ?? m['id'];
-          final name = m['name'] ?? m['symbol'] ?? m['stockName'];
+          final symbol = m['symbol']?.toString() ?? '';
+          final stockName =
+              m['stockName'] ?? m['name'] ?? symbol; // 이름 정보 우선순위
+          final stockImage = m['stockImage'] ?? m['imageUrl'] ?? '';
+
           stocks.add({
             'stockId': id,
-            'name': name ?? '',
+            'symbol': symbol,
+            'stockName': stockName,
+            'stockImage': stockImage,
+            'name': stockName, // 기존 코드 호환을 위해 name 도 유지
           });
         } else {
-          stocks.add({'stockId': null, 'name': e.toString()});
+          // Map 이 아닌 경우 대비: 문자열만 들어오면 기본 구조로 저장
+          stocks.add({
+            'stockId': null,
+            'symbol': e.toString(),
+            'stockName': e.toString(),
+            'stockImage': '',
+            'name': e.toString(),
+          });
         }
       }
     }

--- a/lib/screens/backtest_list_screen.dart
+++ b/lib/screens/backtest_list_screen.dart
@@ -59,7 +59,10 @@ class _BacktestListScreenState extends State<BacktestListScreen> {
                 summary: item,
                 onMore: () async {
                   final detail =
-                  await BacktestService.fetchBacktestResult(item['backtestId']);
+                  await BacktestService.fetchBacktestResult(
+                    item['backtestId'],
+                    stockId: item['stockId'], // 차트/이미지 조회를 위해 종목 ID 전달
+                  );
                   if (!context.mounted) return;
                   Navigator.push(
                     context,

--- a/lib/screens/backtest_result_screen.dart
+++ b/lib/screens/backtest_result_screen.dart
@@ -1,12 +1,11 @@
+// backtest_result_screen.dart
 import 'package:flutter/material.dart';
 import 'package:interactive_chart/interactive_chart.dart';
-import 'package:stockapp/data/candle_api.dart';
+import 'package:stockapp/data/back_candle_api.dart'; // ✅ 파일명 확인
 import 'package:stockapp/data/backtest_api.dart';
-import 'package:stockapp/data/stock_api.dart';
-
-
 import 'dart:math' as math;
 
+/// 백테스트 결과 상세 화면
 class BacktestResultScreen extends StatefulWidget {
   final Map<String, dynamic> result;
   const BacktestResultScreen({super.key, required this.result});
@@ -15,14 +14,20 @@ class BacktestResultScreen extends StatefulWidget {
   State<BacktestResultScreen> createState() => _BacktestResultScreenState();
 }
 
-Map<String, dynamic>? _detail;
-
 class _BacktestResultScreenState extends State<BacktestResultScreen> {
+  // 상세 데이터 (API 재호출 결과) — 화면별 캐시
+  Map<String, dynamic>? _detail;
+
+  // 차트 데이터
   List<CandleData> _candles = [];
   bool _candleLoading = false;
-  List<int> _patternPoints = [];
-  int? _matchStart;
-  int? _matchEnd;
+
+  // 하이라이트(매칭) 관련
+  List<int> _patternPoints = []; // 서버가 별도로 줄 경우만 사용(없으면 빈 리스트)
+  int? _matchStart; // 화면에 그릴 때 사용할 인덱스 기반 시작
+  int? _matchEnd;   // 화면에 그릴 때 사용할 인덱스 기반 끝
+  DateTime? _hlFrom; // 서버 highlightRange.fromDate
+  DateTime? _hlTo;   // 서버 highlightRange.toDate
 
   Map<String, dynamic> get _res {
     final root = _detail ?? widget.result;
@@ -51,28 +56,163 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
     return s.split('T').first;
   }
 
+  DateTime? _parseDate(dynamic s) {
+    if (s == null) return null;
+    final str = s.toString();
+    if (str.isEmpty) return null;
+    return DateTime.tryParse(str);
+  }
+
+  String _intervalFromPeriodUnit(String? unit) {
+    switch ((unit ?? '').toUpperCase()) {
+      case 'MIN':
+      case 'MINUTE':
+        return '1m';
+      case 'H':
+      case 'HOUR':
+        return '1H';
+      case 'D':
+      case 'DAY':
+      default:
+        return '1D';
+    }
+  }
+
+
+  /// 서버에서 전달된 데이터에서 하이라이트 날짜 범위를 파싱하고,
+  /// (하위호환) 기존 인덱스 기반 매칭 키들도 지원한다.
+  void _applyBestMatch(Map<String, dynamic> data) {
+    // 1) highlightRange 우선
+    final hr = data['highlightRange'];
+    final hasHR = hr is Map && (hr['fromDate'] != null && hr['toDate'] != null);
+
+    // 2) 패턴 포인트(있으면)만 먼저 뽑아둔다.
+    List<int> pts = [];
+    final dynamic matchesRaw = data['matches'] ?? data['matchResults'];
+    if (matchesRaw is List && matchesRaw.isNotEmpty) {
+      Map<String, dynamic> best = Map<String, dynamic>.from(matchesRaw.first as Map);
+      double bestReturn = _asNum<double>(
+        best['return'] ?? best['profit'] ?? best['returnRate'] ?? best['rate'],
+      ) ??
+          0;
+
+      for (final m in matchesRaw.skip(1)) {
+        final r = _asNum<double>(m['return'] ?? m['profit'] ?? m['returnRate'] ?? m['rate']) ?? 0;
+        if (r > bestReturn) {
+          best = Map<String, dynamic>.from(m as Map);
+          bestReturn = r;
+        }
+      }
+      final dynamic pp = best['patternPoints'] ?? best['points'];
+      if (pp is List) {
+        pts = pp.map((e) => _asNum<int>(e) ?? 0).toList();
+      }
+
+      if (!hasHR) {
+        final s = _asNum<int>(best['startIndex'] ?? best['matchStartIndex'] ?? best['start']);
+        final e = _asNum<int>(best['endIndex'] ?? best['matchEndIndex'] ?? best['end']);
+        setState(() {
+          _patternPoints = pts;
+          _matchStart = s;
+          _matchEnd = e;
+          _hlFrom = null;
+          _hlTo = null;
+        });
+        return;
+      }
+    }
+
+    if (hasHR) {
+      setState(() {
+        _hlFrom = _parseDate(hr['fromDate']);
+        _hlTo   = _parseDate(hr['toDate']);
+        _patternPoints = pts;
+        _matchStart = null;
+        _matchEnd   = null;
+      });
+      return;
+    }
+
+    final s = _asNum<int>(data['startIndex'] ?? data['matchStartIndex'] ?? data['matchStart']);
+    final e = _asNum<int>(data['endIndex']   ?? data['matchEndIndex']   ?? data['matchEnd']);
+    setState(() {
+      _patternPoints = pts;
+      _matchStart = s;
+      _matchEnd = e;
+      _hlFrom = null;
+      _hlTo = null;
+    });
+  }
+
+  // 앞 뒤 범위 설정
+  Duration _paddingForUnit(String? unit) {
+    switch ((unit ?? '').toUpperCase()) {
+      case 'MIN':
+      case 'MINUTE':
+        return const Duration(hours: 12);  // 앞뒤 6시간
+      case 'H':
+      case 'HOUR':
+        return const Duration(days: 10);   // 앞뒤 5일
+      case 'D':
+      case 'DAY':
+      default:
+        return const Duration(days: 60);  // 앞뒤 45일
+    }
+  }
+
+  /// _hlFrom/_hlTo가 있고 캔들이 채워졌다면, 해당 날짜를 포함하는
+  /// 봉 인덱스 범위를 계산하여 _matchStart/_matchEnd로 설정한다.
+  void _applyHighlightFromDates() {
+    if (_hlFrom == null || _hlTo == null || _candles.isEmpty) return;
+
+    final from = _hlFrom!.toLocal();
+    final to   = _hlTo!.toLocal();
+
+    int? startIdx;
+    for (int i = 0; i < _candles.length; i++) {
+      final t = DateTime.fromMillisecondsSinceEpoch(_candles[i].timestamp).toLocal();
+      if (!t.isBefore(from)) { startIdx = i; break; }
+    }
+    if (startIdx == null) return;
+
+    int endIdx = _candles.length - 1;
+    for (int i = startIdx; i < _candles.length; i++) {
+      final t = DateTime.fromMillisecondsSinceEpoch(_candles[i].timestamp).toLocal();
+      if (t.isAfter(to)) { endIdx = i - 1; break; }
+    }
+    if (endIdx < startIdx) return;
+
+    setState(() { _matchStart = startIdx; _matchEnd = endIdx; });
+  }
+
+  // 생명주기 & 로딩
   @override
   void initState() {
     super.initState();
-    final res = _res;
-    _matchStart = _asNum<int>(res['matchStartIndex'] ?? res['matchStart'] ?? res['startIndex']);
-    _matchEnd = _asNum<int>(res['matchEndIndex'] ?? res['matchEnd'] ?? res['endIndex']);
-
-    _loadDetail();
+    _applyBestMatch(_res); // 초기 데이터에서 하이라이트 후보 설정
+    _loadDetail();         // 상세 재조회 → 최신 데이터로 보정
   }
-
 
   Future<void> _loadDetail() async {
     final id = _asNum<int>(_res['backtestId'] ?? widget.result['backtestId']);
     if (id == null) return;
+
     try {
-      final fetched = await BacktestService.fetchBacktestResult(id); // 백테스트 상세 호출
+      final stockId = _asNum<int>(_res['stockId'] ?? widget.result['stockId']);
+      final fetched = await BacktestService.fetchBacktestResult(
+        id,
+        stockId: stockId,
+      );
+
       setState(() {
         _detail = fetched;
-        _matchStart = _asNum<int>(fetched['matchStartIndex'] ?? fetched['matchStart'] ?? fetched['startIndex']);
-        _matchEnd = _asNum<int>(fetched['matchEndIndex'] ?? fetched['matchEnd'] ?? fetched['endIndex']);
       });
-      _loadCandles();
+
+      // 상세 데이터 기준으로 하이라이트 범위/패턴 재적용
+      _applyBestMatch(fetched);
+
+      // 캔들 전체 로딩
+      await _loadCandles();
     } catch (e) {
       debugPrint('⚠️ 상세 로딩 실패: $e');
     }
@@ -81,30 +221,51 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
   Future<void> _loadCandles() async {
     final res = _res;
 
+    final stockId = (res['stockId'] ?? widget.result['stockId'] ??
+        (res['stock'] is Map ? (res['stock'] as Map)['id'] : null)).toString();
+    final backtestId = _asNum<int>(res['backtestId'] ?? widget.result['backtestId']);
+    if (stockId == 'null' || backtestId == null) return;
 
-    final dynamic stockIdDyn =
-    res['stockId'] ??
-        widget.result['stockId'] ??
-        (res['stock'] is Map ? (res['stock'] as Map)['id'] : null) ??
-        res['symbol'] ??
-        res['stockSymbol'];
-    final String? stockId =
-    (stockIdDyn == null) ? null : stockIdDyn.toString();
+    final periodUnit = (res['periodUnit'] ?? res['PeriodUnit'])?.toString();
+    final interval = _intervalFromPeriodUnit(periodUnit);
 
-    if (stockId == null) {
-      debugPrint('⚠️ stockId가 없어 캔들 요청을 생략합니다.');
-      return;
+    // 백테스트 전체 기간
+    final btStart = _parseDate(res['startDate']);
+    final btEnd   = _parseDate(res['endDate']);
+
+    // 하이라이트가 있으면 앞뒤로 패딩을 줘서 조회 범위 확장
+    final pad = _paddingForUnit(periodUnit);
+    DateTime? qStart, qEnd;
+    if (_hlFrom != null && _hlTo != null) {
+      qStart = _hlFrom!.subtract(pad);
+      qEnd   = _hlTo!.add(pad);
+      // 백테스트 범위를 벗어나지 않게 클램프
+      if (btStart != null && qStart.isBefore(btStart)) qStart = btStart;
+      if (btEnd != null && qEnd.isAfter(btEnd))       qEnd   = btEnd;
+    } else {
+      // 하이라이트가 없으면 백테스트 전체 기간 사용
+      qStart = btStart;
+      qEnd   = btEnd;
     }
 
     setState(() => _candleLoading = true);
     try {
-      final candles = await fetchCandles(stockId: stockId, interval: '1D');
+      final candles = await fetchBacktestCandles(
+        backtestId: backtestId,
+        stockId: stockId,
+        interval: interval,
+        // 서버가 날짜 문자열(yyyy-MM-dd) 받는다면 이렇게 전달
+        startDate: qStart?.toIso8601String().split('T').first,
+        endDate:   qEnd?.toIso8601String().split('T').first,
+      );
+
       setState(() {
-        _candles = candles;
+        _candles = candles;          // ✅ 더 많은 캔들 보유
         _candleLoading = false;
       });
+
+      _applyHighlightFromDates();     // 날짜→인덱스 다시 계산
     } catch (e) {
-      debugPrint('⚠️ 캔들 로딩 실패: $e');
       setState(() {
         _candleLoading = false;
         _candles = [];
@@ -112,9 +273,13 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
     }
   }
 
+  // =========================
+  // UI
+  // =========================
   @override
   Widget build(BuildContext context) {
     final res = _res;
+
     final stockName =
     (res['stockName'] ??
         (res['stock'] is Map ? res['stock']['name'] : null) ??
@@ -122,8 +287,10 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
         '-')
         .toString();
 
-    final String? startDate = res['startDate']?.toString() ?? widget.result['startDate']?.toString();
-    final String? endDate   = res['endDate']?.toString()   ?? widget.result['endDate']?.toString();
+    final String? startDate =
+        res['startDate']?.toString() ?? widget.result['startDate']?.toString();
+    final String? endDate =
+        res['endDate']?.toString() ?? widget.result['endDate']?.toString();
 
     final double? target = _asNum<double>(widget.result['targetReturn']);
 
@@ -133,7 +300,6 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
         title: const Text('백테스팅 결과', style: TextStyle(color: Colors.black)),
         backgroundColor: Colors.white,
         elevation: 0,
-
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Colors.black),
           onPressed: () => Navigator.pop(context),
@@ -144,7 +310,6 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-
             Row(
               children: [
                 Text('실행일: ${res["executedAt"] ?? "-"}',
@@ -155,7 +320,7 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
               ],
             ),
             const SizedBox(height: 12),
-            
+
             Row(
               children: [
                 CircleAvatar(
@@ -167,13 +332,15 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
                       : null,
                   child: (res["stockImage"] == null ||
                       (res["stockImage"] as String).isEmpty)
-                      ? const Icon(Icons.image_not_supported, color: Colors.grey, size: 18)
+                      ? const Icon(Icons.image_not_supported,
+                      color: Colors.grey, size: 18)
                       : null,
                 ),
                 const SizedBox(width: 12),
                 Text(
                   stockName,
-                  style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  style: const TextStyle(
+                      fontSize: 20, fontWeight: FontWeight.bold),
                 ),
               ],
             ),
@@ -197,7 +364,7 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
                   ),
                   if (_matchStart != null &&
                       _matchEnd != null &&
-                      _patternPoints.isNotEmpty)
+                      _matchEnd! >= _matchStart!)
                     Positioned.fill(
                       child: CustomPaint(
                         painter: _MatchOverlayPainter(
@@ -215,11 +382,14 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
 
             Container(
               width: double.infinity,
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+              padding:
+              const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
               decoration: BoxDecoration(
                 color: Colors.white,
                 borderRadius: BorderRadius.circular(12),
-                boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4)],
+                boxShadow: const [
+                  BoxShadow(color: Colors.black12, blurRadius: 4)
+                ],
               ),
               child: Row(
                 children: [
@@ -237,7 +407,9 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
               decoration: BoxDecoration(
                 color: Colors.white,
                 borderRadius: BorderRadius.circular(12),
-                boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4)],
+                boxShadow: const [
+                  BoxShadow(color: Colors.black12, blurRadius: 4)
+                ],
               ),
               child: Column(
                 children: [
@@ -246,33 +418,42 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
                       Expanded(
                         child: Column(
                           children: [
-                            const Text("승률", style: TextStyle(color: Colors.grey)),
+                            const Text("승률",
+                                style: TextStyle(color: Colors.grey)),
                             const SizedBox(height: 4),
                             Text(_fmtPercent(res['winRate']),
                                 style: const TextStyle(
-                                    fontSize: 16, fontWeight: FontWeight.bold, color: Colors.black)),
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.black)),
                           ],
                         ),
                       ),
                       Expanded(
                         child: Column(
                           children: [
-                            const Text("평균 수익률", style: TextStyle(color: Colors.grey)),
+                            const Text("평균 수익률",
+                                style: TextStyle(color: Colors.grey)),
                             const SizedBox(height: 4),
                             Text(_fmtPercent(res['averageReturn']),
                                 style: const TextStyle(
-                                    fontSize: 16, fontWeight: FontWeight.bold, color: Color(0xFF289BF6))),
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color: Color(0xFF289BF6))),
                           ],
                         ),
                       ),
                       Expanded(
                         child: Column(
                           children: [
-                            const Text("최대 수익률", style: TextStyle(color: Colors.grey)),
+                            const Text("최대 수익률",
+                                style: TextStyle(color: Colors.grey)),
                             const SizedBox(height: 4),
                             Text(_fmtPercent(res['maxReturn']),
                                 style: const TextStyle(
-                                    fontSize: 16, fontWeight: FontWeight.bold, color: Color(0xFF289BF6))),
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color: Color(0xFF289BF6))),
                           ],
                         ),
                       ),
@@ -284,41 +465,57 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
                       Expanded(
                         child: Column(
                           children: [
-                            const Text("최대 손실률", style: TextStyle(color: Colors.grey)),
+                            const Text("최대 손실률",
+                                style: TextStyle(color: Colors.grey)),
                             const SizedBox(height: 4),
-                            // ✅ 백엔드에서 최소 수익률(minReturn)을 최대 손실률로 사용
-                            Text(_fmtPercent(res['maxLoss'] ?? res['minReturn']),
+                            // ✅ 서버: minReturn = 최대 손실률 (백워드 호환: maxLoss)
+                            Text(
+                                _fmtPercent(
+                                    res['maxLoss'] ?? res['minReturn']),
                                 style: const TextStyle(
-                                    fontSize: 14, fontWeight: FontWeight.bold, color: Colors.red)),
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.red)),
                           ],
                         ),
                       ),
                       Expanded(
                         child: Column(
                           children: [
-                            const Text("누적 수익률", style: TextStyle(color: Colors.grey)),
+                            const Text("누적 수익률",
+                                style: TextStyle(color: Colors.grey)),
                             const SizedBox(height: 4),
-                            Text(_fmtPercent(res['cumulativeReturn'] ?? res['totalReturn']),
+                            Text(
+                                _fmtPercent(res['cumulativeReturn'] ??
+                                    res['totalReturn']),
                                 style: const TextStyle(
-                                    fontSize: 14, fontWeight: FontWeight.bold, color: Color(0xFF289BF6))),
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.bold,
+                                    color: Color(0xFF289BF6))),
                           ],
                         ),
                       ),
                       Expanded(
                         child: Column(
                           children: [
-                            const Text("마지막 수익률", style: TextStyle(color: Colors.grey)),
+                            const Text("마지막 수익률",
+                                style: TextStyle(color: Colors.grey)),
                             const SizedBox(height: 4),
-                            Text(_fmtPercent(res['lastReturn'] ?? res['lastMatchedReturn']),
+                            Text(
+                                _fmtPercent(res['lastReturn'] ??
+                                    res['lastMatchedReturn']),
                                 style: const TextStyle(
-                                    fontSize: 14, fontWeight: FontWeight.bold, color: Color(0xFF289BF6))),
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.bold,
+                                    color: Color(0xFF289BF6))),
                           ],
                         ),
                       ),
                     ],
                   ),
                   const SizedBox(height: 16),
-                  Text("마지막 매칭일: ${res["lastMatchDate"] ?? res["lastMatchedDate"] ?? "-"}",
+                  Text(
+                      "마지막 매칭일: ${res["lastMatchDate"] ?? res["lastMatchedDate"] ?? "-"}",
                       style: const TextStyle(color: Colors.grey)),
                 ],
               ),
@@ -330,6 +527,7 @@ class _BacktestResultScreenState extends State<BacktestResultScreen> {
   }
 }
 
+/// 매칭 구간/패턴 오버레이 페인터
 class _MatchOverlayPainter extends CustomPainter {
   final int start;
   final int end;
@@ -355,9 +553,9 @@ class _MatchOverlayPainter extends CustomPainter {
       size.height,
     );
 
-    // 매칭 영역 음영 처리
+    // 매칭 영역 음영
     final fill = Paint()
-      ..color = Colors.amber.withValues(alpha: 0.2)
+      ..color = Colors.amber.withValues(alpha: 0.2) // ✅ withOpacity로 호환성↑
       ..style = PaintingStyle.fill;
     canvas.drawRect(rect, fill);
 
@@ -368,7 +566,7 @@ class _MatchOverlayPainter extends CustomPainter {
       ..strokeWidth = 2;
     canvas.drawRect(rect, border);
 
-    // 패턴 모양 그리기
+    // 패턴 모양(선) — 서버가 제공한 경우에만
     if (patternPoints.length >= 2) {
       final minY = patternPoints.reduce(math.min).toDouble();
       final maxY = patternPoints.reduce(math.max).toDouble();
@@ -376,7 +574,8 @@ class _MatchOverlayPainter extends CustomPainter {
 
       final path = Path();
       for (int i = 0; i < patternPoints.length; i++) {
-        final x = rect.left + (i / (patternPoints.length - 1)) * rect.width;
+        final x =
+            rect.left + (i / (patternPoints.length - 1)) * rect.width;
         final normY = (patternPoints[i] - minY) / diffY;
         final y = rect.bottom - normY * rect.height;
         if (i == 0) {
@@ -395,10 +594,10 @@ class _MatchOverlayPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant _MatchOverlayPainter oldDelegate) {
-    return start != oldDelegate.start ||
-        end != oldDelegate.end ||
-        total != oldDelegate.total ||
-        patternPoints != oldDelegate.patternPoints;
+  bool shouldRepaint(covariant _MatchOverlayPainter old) {
+    return start != old.start ||
+        end != old.end ||
+        total != old.total ||
+        patternPoints != old.patternPoints;
   }
 }

--- a/lib/screens/chart_detail_screen.dart
+++ b/lib/screens/chart_detail_screen.dart
@@ -18,7 +18,8 @@ import '../data/backtest_api.dart';
 import '../widgets/backtest/backtest_pop.dart';
 import '../widgets/backtest/recent_backtest_result_card.dart';
 
-
+import 'package:stockapp/models/StockItemModel.dart';
+import 'package:stockapp/screens/stock_detail_screen.dart';
 
 class PatternDetailPage extends StatefulWidget {
   final int patternId;
@@ -144,12 +145,22 @@ class _PatternDetailPageState extends State<PatternDetailPage> {
     }
   }
 
-  Future<void> _applyStockBySymbol(String symbol) async {
+  Future<void> _applyStockBySymbol(String symbol, {int? stockId}) async {
     if (_pattern == null) return;
+
+    // 현재 적용 종목 리스트 복사
     final current = List<Map<String, dynamic>>.from(_pattern!.appliedStockList);
-    final already = current.any((e) => (e['symbol'] ?? e['name']) == symbol);
+
+    // 이미 추가된 종목인지 확인 (symbol 기준)
+    final already = current.any((e) => (e['symbol'] ?? e['stockName'] ?? e['name']) == symbol);
+
+    // 새 종목이면 리스트에 추가
     if (!already) {
-      current.add({'symbol': symbol, 'name': symbol});
+      current.add({
+        'symbol': symbol,
+        'stockName': symbol,
+        'stockId': stockId,
+      });
     }
     final updated = PatternDetail(
       patternId: _pattern!.patternId,
@@ -501,7 +512,10 @@ class _PatternDetailPageState extends State<PatternDetailPage> {
             Map<String, dynamic> detail = backtest;
             if (id != null) {
               // 필요한 정보를 다시 요청하여 상세 화면에 전달
-              detail = await BacktestService.fetchBacktestResult(id as int);
+              detail = await BacktestService.fetchBacktestResult(
+                id as int,
+                stockId: backtest['stockId'], // 차트 생성을 위해 종목 ID 사용
+              );
             }
             if (!context.mounted) return;
             Navigator.push(
@@ -545,19 +559,79 @@ class _PatternDetailPageState extends State<PatternDetailPage> {
             Column(
               children: [
                 for (int i = 0; i < stocks.length; i++) ...[
-                  ListTile(
-                    leading: CircleAvatar(
-                      backgroundImage: NetworkImage(stocks[i]["stockImage"] ?? ""),
-                    ),
-                    title: Text(stocks[i]["stockName"] ?? stocks[i]['name']?.toString() ?? ''),
-                    subtitle: Text("종목코드: ${stocks[i]["symbol"] ?? ''}"),
-                    trailing: IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () => _removeAppliedStockAt(i),
+                  // 피그마 디자인에 맞춘 커스텀 리스트 아이템
+                  InkWell(
+                    onTap: () {
+                      // 텍스트를 탭하면 종목 상세로 이동
+                      final dynamic id = stocks[i]['stockId'];
+                      if (id == null) return; // ID 없으면 이동 중지
+                      final int parsedId =
+                      id is int ? id : int.tryParse(id.toString()) ?? 0;
+                      final stockItem = StockItem(
+                        rank: 0,
+                        stockId: parsedId,
+                        name: stocks[i]["stockName"] ?? '',
+                        price: 0,
+                        changeRate: 0,
+                        imageUrl: stocks[i]["stockImage"] ?? '',
+                      );
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => DetailScreen(stock: stockItem)),
+                      );
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 8, horizontal: 12),
+                      margin: const EdgeInsets.only(bottom: 8),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF7F7F7),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        children: [
+                          // 종목 이미지
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(4),
+                            child: Image.network(
+                              stocks[i]["stockImage"] ?? '',
+                              width: 40,
+                              height: 40,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          // 종목명과 종목코드
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  stocks[i]["stockName"] ??
+                                      stocks[i]['name']?.toString() ?? '',
+                                  style: const TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w500),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  stocks[i]["symbol"] ?? '',
+                                  style: const TextStyle(
+                                      fontSize: 12, color: Colors.grey),
+                                ),
+                              ],
+                            ),
+                          ),
+                          // 삭제 버튼
+                          IconButton(
+                            icon: const Icon(Icons.close, size: 18),
+                            onPressed: () => _removeAppliedStockAt(i),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-
-                  const Divider(height: 1),
                 ]
               ],
             ),
@@ -574,7 +648,13 @@ class _PatternDetailPageState extends State<PatternDetailPage> {
                   ),
                 );
                 if (result is Map<String, dynamic> && result['symbol'] is String) {
-                  await _applyStockBySymbol(result['symbol']);
+                  // 검색 결과에서 ID 도 함께 전달받아 적용한다.
+                  await _applyStockBySymbol(
+                    result['symbol'],
+                    stockId: result['id'] is int
+                        ? result['id']
+                        : int.tryParse(result['id']?.toString() ?? ''),
+                  );
                 }
               },
               style: OutlinedButton.styleFrom(
@@ -588,6 +668,7 @@ class _PatternDetailPageState extends State<PatternDetailPage> {
       ),
     );
   }
+
 
   /// 태그 위젯
   Widget _buildTag(String text) {

--- a/lib/screens/chart_new_screen.dart
+++ b/lib/screens/chart_new_screen.dart
@@ -383,7 +383,7 @@ class _ChartNewScreenState extends State<ChartNewScreen> {
                             decoration: _inputDecoration(),
                             dropdownColor: Colors.white,
                             items: const [
-                              DropdownMenuItem(value: "HOUR", child: Text("분")),
+                              DropdownMenuItem(value: "HOUR", child: Text("시")),
                               DropdownMenuItem(value: "DAY", child: Text("일")),
                             ],
                             onChanged: (val) {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,24 +1,103 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/routes/TabView.dart';
+import 'package:stockapp/screens/signup_screen.dart';
+import 'package:stockapp/services/auth_service.dart';
 
-class LoginScreen extends StatelessWidget {
+/// 로그인 화면
+class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
 
-  void _handleLogin(BuildContext context) {
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(builder: (context) => const Tabview()),
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _authService = AuthService();
+  bool _signupComplete = false;
+
+  /// 로그인 처리 함수
+  Future<void> _handleLogin() async {
+    final success = await _authService.login(
+      _emailController.text,
+      _passwordController.text,
     );
+    if (!mounted) return;
+    if (success) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const Tabview()),
+      );
+    } else {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('로그인 실패')));
+    }
+  }
+
+  /// 회원가입 화면으로 이동
+  Future<void> _goToSignup() async {
+    final result = await Navigator.push<bool>(
+      context,
+      MaterialPageRoute(builder: (context) => const SignUpScreen()),
+    );
+    if (result == true) {
+      setState(() => _signupComplete = true);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('로그인')),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () => _handleLogin(context),
-          child: const Text('로그인'),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 32),
+              const Icon(Icons.image, size: 80), // 디자인용 이미지 자리
+              const SizedBox(height: 32),
+              TextField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: '아이디',
+                  hintText: '아이디를 입력해 주세요.',
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: '비밀번호',
+                  hintText: '비밀번호를 입력해 주세요.',
+                ),
+                obscureText: true,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                height: 48,
+                child: ElevatedButton(
+                  onPressed: _handleLogin,
+                  child: const Text('로그인'),
+                ),
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 48,
+                child: OutlinedButton(
+                  onPressed: _goToSignup,
+                  child: const Text('회원가입'),
+                ),
+              ),
+              const Spacer(),
+              if (_signupComplete)
+                const Text(
+                  '회원가입이 완료되었습니다',
+                  textAlign: TextAlign.center,
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/backtest/backtest_pop.dart
+++ b/lib/widgets/backtest/backtest_pop.dart
@@ -27,9 +27,13 @@ class _BacktestPopupState extends State<BacktestPopup> {
   int? _selectedStockId;
   String? _selectedSymbol;
 
-  // 시작일(종료일은 오늘)
+  // 시작일 선택
   DateTime? _startDate;
   final _startDateController = TextEditingController();
+
+  // 종료일 선택
+  DateTime? _endDate;
+  final _endDateController = TextEditingController();
 
   // 목표 수익률(선택)
   final _profitController = TextEditingController();
@@ -37,6 +41,7 @@ class _BacktestPopupState extends State<BacktestPopup> {
   @override
   void dispose() {
     _startDateController.dispose();
+    _endDateController.dispose();
     _profitController.dispose();
     super.dispose();
   }
@@ -89,6 +94,19 @@ class _BacktestPopupState extends State<BacktestPopup> {
       endDate: endDate,
     );
 
+    if (_endDate == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('종료일을 선택하세요.')),
+      );
+      return;
+    }
+    if (_startDate!.isAfter(_endDate!)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('시작일이 종료일보다 늦습니다.')),
+      );
+      return;
+    }
+
     setState(() => _loading = false);
     final normalized = _normalizeResponse(raw);
 
@@ -102,7 +120,7 @@ class _BacktestPopupState extends State<BacktestPopup> {
         'stockId': _selectedStockId,
         'symbol': _selectedSymbol,
         'startDate': _startDate!.toIso8601String(),
-        'endDate': endDate.toIso8601String(),
+        'endDate': _endDate!.toIso8601String(),
         'result': normalized,
       }));
     } catch (_) {}
@@ -115,8 +133,7 @@ class _BacktestPopupState extends State<BacktestPopup> {
       'stockName': normalized['stockName'] ?? _selectedSymbol,
       'patternId': normalized['patternId'] ?? patternId,
       'startDate': normalized['startDate'] ?? _startDate!.toIso8601String().split('T').first,
-      'endDate': normalized['endDate'] ?? endDate.toIso8601String().split('T').first,
-      'targetReturn': double.tryParse(_profitController.text),
+      'endDate': normalized['endDate'] ?? _endDate!.toIso8601String().split('T').first,      'targetReturn': double.tryParse(_profitController.text),
     };
 
     // 팝업 닫고 결과 화면으로
@@ -241,12 +258,67 @@ class _BacktestPopupState extends State<BacktestPopup> {
                     setState(() {
                       _startDate = picked;
                       _startDateController.text = picked.toIso8601String().split('T').first;
+
+                      // 시작일이 종료일보다 늦지 않도록 조정
+                      if (_endDate != null && _endDate!.isBefore(picked)) {
+                        _endDate = picked;
+                        _endDateController.text = picked.toIso8601String().split('T').first;
+                      }
                     });
                   }
                 },
               ),
 
               const SizedBox(height: 12),
+
+              // 종료일
+              TextField(
+                controller: _endDateController,
+                readOnly: true,
+                decoration: const InputDecoration(
+                  labelText: '백테스팅 종료 날짜 설정',
+                  suffixIcon: Icon(Icons.calendar_today),
+                  filled: true,
+                  fillColor: Colors.white,
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                onTap: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: _endDate ?? _startDate ?? DateTime.now(),
+                    firstDate: _startDate ?? DateTime(2000),
+                    lastDate: DateTime.now(),
+                    builder: (context, child) {
+                      final base = Theme.of(context);
+                      return Theme(
+                        data: base.copyWith(
+                          dialogTheme: const DialogThemeData(
+                            backgroundColor: Colors.white,
+                          ),
+                          colorScheme: const ColorScheme.light(
+                            primary: Colors.black,
+                            onPrimary: Colors.white,
+                            surface: Colors.white,
+                            onSurface: Colors.black,
+                          ),
+                          datePickerTheme: const DatePickerThemeData(
+                            backgroundColor: Colors.white,
+                          ),
+                        ),
+                        child: child!,
+                      );
+                    },
+                  );
+                  if (picked != null) {
+                    setState(() {
+                      _endDate = picked;
+                      _endDateController.text = picked.toIso8601String().split('T').first;
+                    });
+                  }
+                },
+              ),
+              const SizedBox(height: 16),
 
               // 목표 수익률
               TextField(
@@ -261,7 +333,6 @@ class _BacktestPopupState extends State<BacktestPopup> {
                   isDense: true,
                 ),
               ),
-
               const SizedBox(height: 16),
 
               // 버튼들


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
백테스팅시 하이라이트 표시

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #

## ⏳ 작업 내용
- 백테스팅 하이라이트 표시
- 로그인 페이지

## 📸 스크린샷
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 안드로이드 스튜디오 문제로 다시 앱을 깔아야할 듯해서 작업하다 올립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 백테스트 캔들 데이터 조회 추가 및 결과 화면에 서버 지정 하이라이트/패턴 라인 오버레이 지원, 기간 단위 자동 매핑.
  * 로그인 화면 개편: 이메일/비밀번호 로그인, 회원가입 연동, 성공 시 이동 및 완료 안내.
  * 백테스트 팝업에 종료일 입력/달력 선택/검증 추가(시작일-종료일 자동 동기화).
  * 종목 상세 이동 지원 및 적용 종목 관리 개선(중복 방지, stockId 연계), 목록/상세에서 stockId 기반 데이터 로딩.
* 스타일
  * 차트 “단위” 드롭다운에서 HOUR 라벨을 “시”로 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->