### PR TITLE
[REFACTOR] 이미지 종목검색 아이콘, 확장자 수정 #56

### DIFF
--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -116,8 +116,8 @@ class _StockSearchPageState extends State<StockSearchPage> {
                                 ),
                               IconButton(
                                 icon: const Icon(
-                                  Icons.image_search,
-                                  color: Color(0xFF767676),
+                                  Icons.photo_camera,
+                                  color: Colors.black,
                                   size: 26,
                                 ),
                                 onPressed: () {

--- a/lib/services/image_search_api_service.dart
+++ b/lib/services/image_search_api_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import '../models/image_search_result.dart';
 
 class ImageSearchApiService {
@@ -39,11 +40,16 @@ class ImageSearchApiService {
   }) async {
     final filename = imageFile.path.split('/').last;
 
+    final mimeType = lookupMimeType(imageFile.path) ?? 'image/jpeg';
+    final typeSplit = mimeType.split('/');
+
+    print('[UPLOAD] filename=$filename, mimeType=$mimeType, path=${imageFile.path}');
+
     final formData = FormData.fromMap({
       'image': await MultipartFile.fromFile(
         imageFile.path,
         filename: filename,
-        contentType: MediaType('image', 'jpeg'),
+        contentType: MediaType(typeSplit[0], typeSplit[1]),
       ),
     });
 

--- a/lib/widgets/common/searchBar.dart
+++ b/lib/widgets/common/searchBar.dart
@@ -34,7 +34,7 @@ class StockSerachBar extends StatelessWidget {
               ],
             ),
             IconButton(
-              icon: const Icon(Icons.image_search, color: Color(0xFF767676), size: 26),
+              icon: const Icon(Icons.photo_camera, color: Colors.black, size: 26),
               onPressed: () {
                 Navigator.push(
                   context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   image_picker: ^1.0.7
   permission_handler: ^11.3.0
   http_parser: ^4.0.2
+  mime: ^2.0.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
이미지 종목검색 아이콘 변경,
모든 이미지 확장자 지원하도록 수정했습니다.

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #56

## ⏳ 작업 내용
- 

## 📸 스크린샷
- 
<img width="358" height="635" alt="image" src="https://github.com/user-attachments/assets/21c1e988-4af9-441c-bd7c-896f95ce7bba" />

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 검색 바의 우측 아이콘을 회색 이미지 검색에서 검은색 카메라 아이콘으로 변경했습니다. 크기와 동작(이미지 검색 화면 이동)은 동일합니다.
  - 동일한 아이콘 변경이 검색 화면과 공통 검색 바 위젯에 반영되었습니다.

- 버그 수정
  - 이미지 업로드 시 파일의 실제 MIME 유형을 자동 감지해 전송하도록 개선했습니다. 잘못된 Content-Type으로 인해 발생하던 업로드 실패나 오인식을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->