### PR TITLE
[FEAT] 관심 종목 페이지 백테스팅 진행

### DIFF
--- a/lib/data/pattern_apply_api.dart
+++ b/lib/data/pattern_apply_api.dart
@@ -28,10 +28,21 @@ class PatternApplyApi {
     num minValidReturn = 0,
   }) async {
     // 1) 삭제
-    final del = await _dio.delete('/pattern-applies/$patternApplyId');
-    if (del.statusCode != 200 || del.data is! Map || (del.data['isSuccess'] != true)) {
-      final msg = (del.data is Map ? del.data['message'] : null) ?? '패턴 해제 실패';
-      throw Exception('DELETE 실패: $msg (HTTP ${del.statusCode})');
+    final del = await _dio.delete(
+      '/pattern-applies/$patternApplyId',
+      options: Options(validateStatus: (s) => s != null && s < 500),
+    );
+    final delOk =
+        (del.statusCode != null &&
+            del.statusCode! >= 200 &&
+            del.statusCode! < 300);
+    if (delOk) {
+      if (del.data is Map && (del.data['isSuccess'] != true)) {
+        final msg = (del.data['message']) ?? '패턴 해제 실패';
+        throw Exception('DELETE 실패: $msg (HTTP ${del.statusCode})');
+      }
+    } else {
+      throw Exception('DELETE 실패: HTTP ${del.statusCode}');
     }
 
     // 2) 재적용
@@ -41,9 +52,18 @@ class PatternApplyApi {
       'entryAt': (entryAt ?? DateTime.now()).toUtc().toIso8601String(),
       'minValidReturn': minValidReturn,
     };
-    final post = await _dio.post('/pattern-applies', data: body);
-    if (post.statusCode != 200 || post.data is! Map || (post.data['isSuccess'] != true)) {
-      final msg = (post.data is Map ? post.data['message'] : null) ?? '패턴 재적용 실패';
+    final post = await _dio.post(
+      '/pattern-applies',
+      data: body,
+      options: Options(validateStatus: (s) => s != null && s < 500),
+    );
+    final postOk =
+        (post.statusCode != null &&
+            post.statusCode! >= 200 &&
+            post.statusCode! < 300);
+    if (!postOk || post.data is! Map || (post.data['isSuccess'] != true)) {
+      final msg =
+          (post.data is Map ? post.data['message'] : null) ?? '패턴 재적용 실패';
       throw Exception('POST 실패: $msg (HTTP ${post.statusCode})');
     }
   }
@@ -95,9 +115,8 @@ class PatternApplyApi {
       final data = res.data as Map<String, dynamic>;
       if (data['isSuccess'] == true) {
         final result = data['result'];
-        final id = (result is Map)
-            ? (result['patternApplyId'] ?? result['id'])
-            : null;
+        final id =
+            (result is Map) ? (result['patternApplyId'] ?? result['id']) : null;
         if (id is num) return id.toInt();
         throw Exception('응답에 patternApplyId가 없습니다: ${res.data}');
       }

--- a/lib/screens/interest/interest_pattern_screen.dart
+++ b/lib/screens/interest/interest_pattern_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:stockapp/data/backtest_api.dart';
 import 'package:stockapp/data/interest_pattern_api.dart';
 import 'package:stockapp/data/pattern_apply_api.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/screens/interest/pattern_library_screen.dart';
 import 'package:stockapp/widgets/common/app_confirm_dialog.dart';
+import 'package:stockapp/widgets/interest/backtest_config_dialog.dart';
 import 'package:stockapp/widgets/interest/pattern_empty_view.dart';
 import 'package:stockapp/widgets/interest/pattern_exists_view.dart';
 import 'package:stockapp/widgets/interest/pattern_stock_header.dart';
@@ -23,6 +25,51 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
   final _api = PatternApi();
   late Future<PatternApply?> _future;
   final _applyApi = PatternApplyApi(); // delete 호출
+  bool _runningBacktest = false;
+
+  Future<void> _onRunBacktest(int patternId) async {
+    // 1) 다이얼로그로 입력 받기
+    final cfg = await showBacktestConfigDialog(context);
+    if (cfg == null) return;
+
+    setState(() => _runningBacktest = true);
+    try {
+      // 2) API 호출
+      await BacktestService.run(
+        patternId: patternId,
+        stockId: widget.stockId,
+        startDate: cfg.startDate,
+        endDate: cfg.endDate,
+      );
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('백테스팅이 실행되었습니다.')));
+
+      // 3) 결과 새로고침
+      await Future.delayed(const Duration(seconds: 1));
+
+      try {
+        await _reload(); // 결과 조회
+      } catch (e) {
+        debugPrint('새로고침 실패: $e');
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('결과가 아직 준비 중입니다. 잠시 후 다시 시도해주세요.')),
+          );
+        }
+      }
+    } catch (e) {
+      if (!mounted) return;
+      // 실행 자체가 실패한 경우에만 이쪽으로 옴
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('백테스팅 실행 실패: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _runningBacktest = false);
+    }
+  }
 
   @override
   void initState() {
@@ -134,7 +181,9 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
                         ),
                       ),
                     );},
-                    onRunBacktest: () {/* TODO */},
+                    onRunBacktest: _runningBacktest
+                        ? null
+                        : () => _onRunBacktest(data.pattern!.patternId),
                   )
                       : PatternEmptyView(
                     onAdd: () async {

--- a/lib/widgets/common/dialog/app_date_field.dart
+++ b/lib/widgets/common/dialog/app_date_field.dart
@@ -1,0 +1,59 @@
+// lib/widgets/common/app_date_field.dart
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'app_date_picker.dart';
+
+class AppDateField extends StatelessWidget {
+  final String label;
+  final DateTime value;
+  final ValueChanged<DateTime> onChanged;
+  final DateFormat format;
+  final DateTime? firstDate;
+  final DateTime? lastDate;
+
+  // ← const 빼기!
+  AppDateField({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    DateFormat? format,
+    this.firstDate,
+    this.lastDate,
+  }) : format = format ?? DateFormat('yyyy-MM-dd');
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
+        const SizedBox(height: 6),
+        TextFormField(
+          readOnly: true,
+          controller: TextEditingController(text: this.format.format(value)),
+          decoration: InputDecoration(
+            isDense: true,
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.calendar_today),
+              onPressed: () async {
+                final picked = await showThemedDatePicker(
+                  context,
+                  initialDate: value,
+                  firstDate: firstDate,
+                  lastDate: lastDate,
+                );
+                if (picked != null) {
+                  onChanged(DateTime(picked.year, picked.month, picked.day));
+                }
+              },
+            ),
+            border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+            contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/common/dialog/app_date_picker.dart
+++ b/lib/widgets/common/dialog/app_date_picker.dart
@@ -1,0 +1,36 @@
+// lib/widgets/common/app_date_picker.dart
+import 'package:flutter/material.dart';
+
+Future<DateTime?> showThemedDatePicker(
+    BuildContext context, {
+      required DateTime initialDate,
+      DateTime? firstDate,
+      DateTime? lastDate,
+    }) {
+  return showDatePicker(
+    context: context,
+    initialDate: initialDate,
+    firstDate: firstDate ?? DateTime(2000, 1, 1),
+    lastDate:  lastDate  ?? DateTime(2100, 12, 31),
+    builder: (ctx, child) {
+      final base = Theme.of(ctx);
+      return Theme(
+        data: base.copyWith(
+          colorScheme: const ColorScheme.light(
+            primary: Colors.black,   // 선택칩/헤더 포인트
+            onPrimary: Colors.white, // 헤더/선택칩 글자
+            onSurface: Colors.black, // 본문 텍스트
+          ),
+          textButtonTheme: TextButtonThemeData(
+            style: TextButton.styleFrom(foregroundColor: Colors.black),
+          ),
+          datePickerTheme: const DatePickerThemeData(
+            headerBackgroundColor: Colors.white,
+            headerForegroundColor: Colors.black,
+          ),
+        ),
+        child: child!,
+      );
+    },
+  );
+}

--- a/lib/widgets/common/dialog/app_number_field.dart
+++ b/lib/widgets/common/dialog/app_number_field.dart
@@ -1,0 +1,38 @@
+// lib/widgets/common/app_number_field.dart
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class AppNumberField extends StatelessWidget {
+  final String label;
+  final TextEditingController controller;
+  final String? hintText;
+
+  const AppNumberField({
+    super.key,
+    required this.label,
+    required this.controller,
+    this.hintText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
+        const SizedBox(height: 6),
+        TextField(
+          controller: controller,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: false),
+          inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))],
+          decoration: InputDecoration(
+            isDense: true,
+            hintText: hintText,
+            border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+            contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
+import 'package:stockapp/screens/backtest/backtest_result_screen.dart';
 import 'package:stockapp/widgets/common/InfoCardGroup.dart';
 import 'dart:math' as math;
 import 'package:stockapp/widgets/common/app_button.dart';
@@ -55,7 +56,17 @@ class BacktestResultCard extends StatelessWidget {
                   Text('${result.startDate} ~ ${result.endDate}', style: TextStyles.valueText,),
                   const Spacer(),
                   TextButton(
-                      onPressed: () {},
+                    onPressed: () {
+                      // Navigator.of(context).push(
+                      //   MaterialPageRoute(
+                      //     builder: (_) => BacktestResultScreen(
+                      //       patternId: patt.patternId,
+                      //       stockId: data.stockId,
+                      //       stockName: data.stockName, // 앱바 타이틀용
+                      //     ),
+                      //   ),
+                      // );
+                    },
                     style: TextButton.styleFrom(
                       minimumSize: Size.zero,
                       padding: EdgeInsets.zero,

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -3,6 +3,8 @@ import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/common/InfoCardGroup.dart';
 import 'dart:math' as math;
 
+import 'package:stockapp/widgets/common/app_button.dart';
+
 class BacktestResultCard extends StatelessWidget {
   final BacktestResult result;
   const BacktestResultCard({required this.result});
@@ -27,56 +29,61 @@ class BacktestResultCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-          padding: const EdgeInsets.all(14),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 2),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // 기간/실행일
-              Text('기간 ${result.startDate} ~ ${result.endDate}'),
+              // 실행일, 매칭 횟수
               Row(
                 children: [
-                  Text('실행 날짜 ${result.executedAt}',
-                      style: TextStyle(color: Colors.grey.shade600, fontSize: 14)),
-                  const Spacer(),
-                  Text('매칭 횟수 : ${result.matchedCount}'),
+                  Text('실행 날짜 : ',
+                      style: TextStyles.partName),
+                  Text('${result.executedAt}', style: TextStyles.valueText,),
+                  SizedBox(width: 10),
+                  Text('매칭 횟수 : ', style: TextStyles.partName),
+                  Text('${result.matchedCount}', style: TextStyles.valueText,),
                 ],
+
               ),
               const SizedBox(height: 12),
+              //패턴
+
+
+              //기간
+              Row(
+                children: [
+                  Text('기간 : ', style: TextStyles.partName,),
+                  Text('${result.startDate} ~ ${result.endDate}', style: TextStyles.valueText,),
+                  const Spacer(),
+                  TextButton(
+                      onPressed: () {},
+                    style: TextButton.styleFrom(
+                      minimumSize: Size.zero,
+                      padding: EdgeInsets.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                      child: Text('더보기',
+                        style: TextStyle(color: Color(0xFF9D9D9D), fontSize: 13),
+                      ),
+                  ),
+                ],
+              ),
 
               // 지표들
               InfoCardGroup(
                 rows: [
                   {'label': '승률', 'value': _fmtPct(result.winRate, decimals: 1)},
-                  {'label': '평균 수익', 'value': _fmtPct(result.averageReturn, decimals: 2, inputIsRatio: false), 'color': const Color(0xFF289BF6)},
-                  {'label': '최대 수익', 'value': _fmtPct(result.maxReturn,   decimals: 2, round: false), 'subValue': result.maxReturnDate,'color': const Color(0xFF289BF6)},
+                  {'label': '평균 수익', 'value': _fmtPct(result.averageReturn, decimals: 2, inputIsRatio: false), 'color': const Color(0xFF1573FE)},
+                  {'label': '최대 수익', 'value': _fmtPct(result.maxReturn,   decimals: 2, round: false), 'subValue': result.maxReturnDate,'color': const Color(0xFF1573FE)},
                 ],),
 
               const SizedBox(height: 12),
               Align(
                 alignment: Alignment.centerRight,
-                child: ElevatedButton(
-                  onPressed: () {
-                    // TODO: 재실행 API 있으면 호출 후 상단 RefreshIndicator로 갱신
-                  },
-                  style:  ElevatedButton.styleFrom(
-                // 메인 컬러
-                // primary: Colors.red, // Deprecated
-                // 텍스트색상, ripple컬러
-                foregroundColor: Colors.white,
-                  // 버튼 배경 색
-                  backgroundColor: Colors.black,
-                  textStyle:
-                  TextStyle(fontWeight: FontWeight.w500, fontSize: 12),
-                  // 글자 주변에 적용
-                  padding: EdgeInsets.all(12),
-                  // 테두리 설정
-                  side: BorderSide( color: Colors.black, width: 1),
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8)
-                  ),
-                ),
-                  child: const Text('다시 돌리기'),
-                ),
+                child: AppButton(
+                    label: '다시 돌리기',
+                    onPressed: () {}
+                )
               ),
             ],
           )
@@ -108,4 +115,15 @@ class _Metric extends StatelessWidget {
       ),
     );
   }
+}
+
+class TextStyles {
+  static const TextStyle partName = TextStyle(
+      color: Color(0xFF8198A5),
+      fontSize: 14
+  );
+  static const TextStyle valueText= TextStyle(
+      fontWeight: FontWeight.w500,
+      fontSize: 13
+  );
 }

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/common/InfoCardGroup.dart';
 import 'dart:math' as math;
-
 import 'package:stockapp/widgets/common/app_button.dart';
 
 class BacktestResultCard extends StatelessWidget {
@@ -77,14 +76,6 @@ class BacktestResultCard extends StatelessWidget {
                   {'label': '최대 수익', 'value': _fmtPct(result.maxReturn,   decimals: 2, round: false), 'subValue': result.maxReturnDate,'color': const Color(0xFF1573FE)},
                 ],),
 
-              const SizedBox(height: 12),
-              Align(
-                alignment: Alignment.centerRight,
-                child: AppButton(
-                    label: '다시 돌리기',
-                    onPressed: () {}
-                )
-              ),
             ],
           )
     );

--- a/lib/widgets/interest/backtest_config_dialog.dart
+++ b/lib/widgets/interest/backtest_config_dialog.dart
@@ -1,0 +1,81 @@
+// lib/widgets/interest/backtest_config_dialog.dart
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:stockapp/widgets/common/app_button.dart';
+import 'package:stockapp/widgets/common/dialog/app_date_field.dart';
+
+class BacktestConfig {
+  final DateTime startDate;
+  final DateTime endDate;
+  BacktestConfig({required this.startDate, required this.endDate});
+}
+
+Future<BacktestConfig?> showBacktestConfigDialog(
+    BuildContext context, {
+      DateTime? initialStart,
+      DateTime? initialEnd,
+    }) {
+  DateTime start = initialStart ?? DateTime.now().subtract(const Duration(days: 30));
+  DateTime end   = initialEnd   ?? DateTime.now();
+
+  bool isValidRange() {
+    final s = DateTime(start.year, start.month, start.day);
+    final e = DateTime(end.year, end.month, end.day);
+    return !e.isBefore(s);
+  }
+
+  return showDialog<BacktestConfig>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) {
+      return StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          backgroundColor: Colors.white,
+          title: const Text('백테스팅 설정', style: TextStyle(fontWeight: FontWeight.w700, fontSize: 20)),
+          content: SizedBox(
+            width: 360,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppDateField(
+                  label: '백테스팅 시작 날짜',
+                  value: start,
+                  onChanged: (d) => setState(() => start = d),
+                  format: DateFormat('yyyy-MM-dd'),
+                ),
+                const SizedBox(height: 12),
+                AppDateField(
+                  label: '백테스팅 종료 날짜',
+                  value: end,
+                  onChanged: (d) => setState(() => end = d),
+                  format: DateFormat('yyyy-MM-dd'),
+                ),
+                if (!isValidRange())
+                  const Padding(
+                    padding: EdgeInsets.only(top: 8),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text('종료일은 시작일 이후여야 해요', style: TextStyle(color: Colors.red)),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          actions: [
+            AppButton(label: '취소', onPressed: () => Navigator.pop(ctx),
+              textStyle: TextStyle(fontSize: 13),
+              fgColor: Colors.black,
+              bgColor:  Color(0xFFF5F5F5),
+              side: BorderSide(color: Colors.black, width: 1),),
+            AppButton(label: '백테스팅 진행',
+                textStyle: TextStyle(fontSize: 13),
+              onPressed: isValidRange()
+                ? () => Navigator.pop(ctx, BacktestConfig(startDate: start, endDate: end))
+                : null,),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/widgets/interest/pattern_apply_dialog.dart
+++ b/lib/widgets/interest/pattern_apply_dialog.dart
@@ -1,8 +1,10 @@
+// lib/widgets/interest/pattern_apply_dialog.dart
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:stockapp/widgets/common/app_button.dart';
 import 'package:stockapp/models/pattern_apply_input.dart';
+import 'package:stockapp/widgets/common/dialog/app_date_field.dart';
+import 'package:stockapp/widgets/common/dialog/app_number_field.dart';
 
 Future<PatternApplyInput?> showPatternApplyDialog(
     BuildContext context, {
@@ -11,10 +13,8 @@ Future<PatternApplyInput?> showPatternApplyDialog(
       bool isUpdate = false,
       bool barrierDismissible = true,
     }) {
-  final dateFmt = DateFormat('yyyy-MM-dd');
   DateTime selected = initialDate ?? DateTime.now();
-  final controller =
-  TextEditingController(text: (initialMinValidReturn ?? 0).toString());
+  final minCtrl = TextEditingController(text: (initialMinValidReturn ?? 0).toString());
 
   return showDialog<PatternApplyInput>(
     context: context,
@@ -28,88 +28,31 @@ Future<PatternApplyInput?> showPatternApplyDialog(
           constraints: const BoxConstraints(maxWidth: 360),
           child: StatefulBuilder(
             builder: (ctx, setState) => SingleChildScrollView(
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(ctx).viewInsets.bottom,
-              ),
+              padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text(
-                    '패턴적용 설정',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                  const Text('패턴적용 설정', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
+                  const SizedBox(height: 12),
+
+                  AppDateField(
+                    label: '패턴 적용 일시',
+                    value: selected,
+                    onChanged: (d) => setState(() => selected = d),
+                    format: DateFormat('yyyy-MM-dd'),
                   ),
                   const SizedBox(height: 12),
 
-                  const Text('패턴 적용 일시',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  const SizedBox(height: 6),
-                  TextFormField(
-                    readOnly: true,
-                    controller:
-                    TextEditingController(text: dateFmt.format(selected)),
-                    decoration: InputDecoration(
-                      suffixIcon: IconButton(
-                        icon: const Icon(Icons.calendar_today),
-                        onPressed: () async {
-                          final picked = await showDatePicker(
-                            context: ctx,
-                            initialDate: selected,
-                            firstDate: DateTime(2000),
-                            lastDate: DateTime(2100),
-                            builder: (context, child) {
-                              return Theme(
-                                data: Theme.of(context).copyWith(
-                                  colorScheme: const ColorScheme.light(
-                                    primary: Colors.black,
-                                    onPrimary: Colors.white,
-                                    onSurface: Colors.black,
-                                  ),
-                                  textButtonTheme: TextButtonThemeData(
-                                    style: TextButton.styleFrom(
-                                        foregroundColor: Colors.black),
-                                  ),
-                                  datePickerTheme: const DatePickerThemeData(
-                                    headerBackgroundColor: Colors.white,
-                                    headerForegroundColor: Colors.black,
-                                  ),
-                                ),
-                                child: child!,
-                              );
-                            },
-                          );
-                          if (picked != null) setState(() => selected = picked);
-                        },
-                      ),
-                      border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8)),
-                      contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 12),
-                    ),
-                  ),
-
-                  const SizedBox(height: 12),
-                  const Text('최소수익률 조건',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  const SizedBox(height: 6),
-                  TextField(
-                    controller: controller,
-                    keyboardType: const TextInputType.numberWithOptions(
-                        decimal: true, signed: false),
-                    inputFormatters: [
-                      FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-                    ],
-                    decoration: InputDecoration(
-                      hintText: '예: 12.5',
-                      border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8)),
-                      contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 12),
-                    ),
+                  AppNumberField(
+                    label: '최소수익률 조건',
+                    controller: minCtrl,
+                    hintText: '예: 12.5',
                   ),
 
                   const SizedBox(height: 16),
                   Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       AppButton(
                         onPressed: () => Navigator.pop(ctx),
@@ -121,20 +64,9 @@ Future<PatternApplyInput?> showPatternApplyDialog(
                       const SizedBox(width: 8),
                       AppButton(
                         onPressed: () {
-                          final minReturn =
-                              double.tryParse(controller.text.trim()) ?? 0.0;
-                          final atUtc = DateTime(
-                            selected.year,
-                            selected.month,
-                            selected.day,
-                          ).toUtc();
-                          Navigator.pop(
-                            ctx,
-                            PatternApplyInput(
-                              entryAt: atUtc,
-                              minValidReturn: minReturn,
-                            ),
-                          );
+                          final minReturn = double.tryParse(minCtrl.text.trim()) ?? 0.0;
+                          final atUtc = DateTime(selected.year, selected.month, selected.day).toUtc();
+                          Navigator.pop(ctx, PatternApplyInput(entryAt: atUtc, minValidReturn: minReturn));
                         },
                         label: (isUpdate ? '패턴 수정' : '패턴 추가'),
                       ),

--- a/lib/widgets/interest/pattern_apply_dialog.dart
+++ b/lib/widgets/interest/pattern_apply_dialog.dart
@@ -1,14 +1,8 @@
-// lib/widgets/interest/pattern_apply_dialog.dart
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:stockapp/widgets/common/app_button.dart';
-
-class PatternApplyInput {
-  final DateTime entryAt;       // UTC로 보낼 일시
-  final double minValidReturn;  // 최소 수익률
-  PatternApplyInput({required this.entryAt, required this.minValidReturn});
-}
+import 'package:stockapp/models/pattern_apply_input.dart';
 
 Future<PatternApplyInput?> showPatternApplyDialog(
     BuildContext context, {
@@ -41,11 +35,14 @@ Future<PatternApplyInput?> showPatternApplyDialog(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text('패턴적용 설정',
-                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
+                  const Text(
+                    '패턴적용 설정',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                  ),
                   const SizedBox(height: 12),
 
-                  const Text('패턴 적용 일시', style: TextStyle(fontWeight: FontWeight.w600)),
+                  const Text('패턴 적용 일시',
+                      style: TextStyle(fontWeight: FontWeight.w600)),
                   const SizedBox(height: 6),
                   TextFormField(
                     readOnly: true,
@@ -63,17 +60,15 @@ Future<PatternApplyInput?> showPatternApplyDialog(
                             builder: (context, child) {
                               return Theme(
                                 data: Theme.of(context).copyWith(
-                                  // 선택된 날짜/헤더 색상 등 핵심 포인트
                                   colorScheme: const ColorScheme.light(
-                                    primary: Colors.black,   // 선택된 날짜 배경 & 헤더 강조색
-                                    onPrimary: Colors.white, // 선택된 날짜 텍스트 & 헤더 텍스트
-                                    onSurface: Colors.black, // 기본 텍스트
+                                    primary: Colors.black,
+                                    onPrimary: Colors.white,
+                                    onSurface: Colors.black,
                                   ),
-                                  // 확인/취소 버튼 색
                                   textButtonTheme: TextButtonThemeData(
-                                    style: TextButton.styleFrom(foregroundColor: Colors.black),
+                                    style: TextButton.styleFrom(
+                                        foregroundColor: Colors.black),
                                   ),
-                                  // 세부 커스터마이즈 (Flutter 3.10+)
                                   datePickerTheme: const DatePickerThemeData(
                                     headerBackgroundColor: Colors.white,
                                     headerForegroundColor: Colors.black,
@@ -94,7 +89,8 @@ Future<PatternApplyInput?> showPatternApplyDialog(
                   ),
 
                   const SizedBox(height: 12),
-                  const Text('최소수익률 조건', style: TextStyle(fontWeight: FontWeight.w600)),
+                  const Text('최소수익률 조건',
+                      style: TextStyle(fontWeight: FontWeight.w600)),
                   const SizedBox(height: 6),
                   TextField(
                     controller: controller,
@@ -120,14 +116,13 @@ Future<PatternApplyInput?> showPatternApplyDialog(
                         label: '취소',
                         bgColor: Colors.white,
                         fgColor: Colors.black,
-                        side: BorderSide(color: Colors.black, width: 1),
+                        side: const BorderSide(color: Colors.black, width: 1),
                       ),
                       const SizedBox(width: 8),
                       AppButton(
                         onPressed: () {
                           final minReturn =
                               double.tryParse(controller.text.trim()) ?? 0.0;
-                          // 날짜만 선택 → 자정(로컬)을 UTC로 변환
                           final atUtc = DateTime(
                             selected.year,
                             selected.month,

--- a/lib/widgets/interest/pattern_chip.dart
+++ b/lib/widgets/interest/pattern_chip.dart
@@ -10,8 +10,8 @@ class PatternChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
-        color: Colors.grey.shade200,
-        borderRadius: BorderRadius.circular(999),
+        color: Color(0xFFF4F4F4),
+        borderRadius: BorderRadius.circular(8),
       ),
       child: Text(text, style: const TextStyle(fontSize: 12)),
     );

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -1,11 +1,9 @@
-// lib/widgets/interest/pattern/pattern_exists_view.dart
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/common/app_button.dart';
 import 'package:stockapp/widgets/common/pattern_line_chart.dart';
 import 'package:stockapp/widgets/interest/BacktestResultCard.dart';
 import 'package:stockapp/widgets/interest/pattern_alert_button.dart';
-import 'package:stockapp/widgets/interest/pattern_chart_card.dart';
 import 'package:stockapp/widgets/interest/pattern_controls_row.dart';
 import 'package:stockapp/widgets/interest/pattern_section_header.dart';
 
@@ -37,7 +35,7 @@ class PatternExistsView extends StatelessWidget {
           child: Row(
             children: [
               const Expanded(
-                child: PatternSectionHeader(title: '내 전략 패턴'),
+                child: Text('내 전략 패턴', style: TextStyles.sectionHeader),
               ),
               if (data.patternApplyId != null)
                 PatternAlertButton(
@@ -58,8 +56,15 @@ class PatternExistsView extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Container(
-              color: Colors.white,
-              child: PatternLineChart(points: patt.points)
+            decoration: BoxDecoration(
+              color: Color(0xFFF4F4F4),
+              borderRadius: BorderRadius.circular(8),
+            ),
+              padding: const EdgeInsets.all(12),
+              child: Container(
+                color: Colors.white,
+                  child: PatternLineChart(points: patt.points)
+              )
           ),
         ),
         const SizedBox(height: 12),
@@ -74,10 +79,20 @@ class PatternExistsView extends StatelessWidget {
             onEdit: onEdit,
           ),
         ),
-        const SizedBox(height: 20),
+        SizedBox(height: 8),
+        const SizedBox(height: 13, child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Color(0xFFEFEFEF),
+          ),
+        ),),
+        SizedBox(height: 10),
 
         // 백테스팅
-        const PatternSectionHeader(title: '최근 백테스팅 결과'),
+        // const PatternSectionHeader(title: '최근 백테스팅 결과'),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 15),
+          child: Text('최근 백테스팅 결과', style: TextStyles.sectionHeader),
+        ),
         if (data.hasBacktest)
           BacktestResultCard(result: data.backtest!)
         else
@@ -91,4 +106,12 @@ class PatternExistsView extends StatelessWidget {
       ],
     );
   }
+}
+
+class TextStyles {
+  static const TextStyle sectionHeader = TextStyle(
+    fontWeight: FontWeight.w600,
+    fontSize: 19,
+  );
+
 }

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -100,7 +100,10 @@ class PatternExistsView extends StatelessWidget {
               SizedBox(height: 12),
               Align(
                 alignment: Alignment.centerRight,
-                child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
+                ),
               )
             ]
           )

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -94,7 +94,16 @@ class PatternExistsView extends StatelessWidget {
           child: Text('최근 백테스팅 결과', style: TextStyles.sectionHeader),
         ),
         if (data.hasBacktest)
-          BacktestResultCard(result: data.backtest!)
+          Column(
+            children: [
+              BacktestResultCard(result: data.backtest!),
+              SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
+              )
+            ]
+          )
         else
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/widgets/interest/pattern_section_header.dart
+++ b/lib/widgets/interest/pattern_section_header.dart
@@ -9,7 +9,7 @@ class PatternSectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-      child: Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+      child: Text(title, style: const TextStyle(fontSize: 19, fontWeight: FontWeight.w600)),
     );
   }
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
관심 종목 페이지 백테스팅 진행 추가

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #64 

## ⏳ 작업 내용
- 관심 종목 페이지에서 백테스팅 진행하는 기능 추가
- 관심 종목 페이지 디자인 수정

## 📸 스크린샷
https://github.com/user-attachments/assets/91bad4ba-4475-4b8e-8341-f982c5ce1ddd


## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- SnackBar '결과가 아직 준비 중입니다. 잠시 후 다시 시도해주세요.' 뜨는 부분 backtest_api.dart 파일을 수정해야 해서 추후에 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 패턴 상세에서 백테스트 실행 흐름 추가(설정 다이얼로그, 중복 실행 방지, 실행/오류 스낵바, 결과 새로고침).
  - 기간 선택용 날짜 필드(AppDateField)와 테마 적용 날짜 선택기 도입.
  - 숫자 입력 필드(AppNumberField) 추가.
  - 백테스트 설정 다이얼로그 제공(기간 유효성 검사, 진행/취소).
- Refactor
  - 패턴 적용/삭제/교체 API 응답 처리 개선(2xx 상태 검증, 성공 여부 세분화, 서버 메시지 보존).
  - 패턴 적용 다이얼로그 입력 컴포넌트 표준화 및 모델 분리.
- Style
  - 백테스트 결과 카드·섹션 헤더·차트 영역 시각 개선.
  - 패턴 칩 색상/모서리 라운드 조정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->