### PR TITLE
[FEAT] 투자 일기 삭제 기능

### DIFF
--- a/lib/data/emotion_diary_api.dart
+++ b/lib/data/emotion_diary_api.dart
@@ -28,4 +28,13 @@ class EmotionDiaryApi {
       rethrow;
     }
   }
+
+  /// 삭제
+  Future<void> deleteDiary(int diaryId) async {
+    final response = await _dio.delete('/diaries/$diaryId');
+    if (response.statusCode != 200) {
+      throw Exception('삭제 실패');
+    }
+  }
+
 }

--- a/lib/screens/diary_screen.dart
+++ b/lib/screens/diary_screen.dart
@@ -147,10 +147,11 @@ class _DiaryScreenState extends State<DiaryScreen> {
             Expanded(
               child: ListView(
                 controller: _scrollController, //페이지 진입 시 맨 아래로 이동
-                padding: const EdgeInsets.symmetric(horizontal: 20),
+                padding: const EdgeInsets.symmetric(horizontal: 15),
                 children: _buildGroupedDiaryWidgets(),
               ),
             ),
+            SizedBox(height: 4),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: EmotionInputBar(onSubmit: _submitDiary),

--- a/lib/screens/diary_screen.dart
+++ b/lib/screens/diary_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:stockapp/data/emotion_diary_api.dart';
+import 'package:stockapp/widgets/common/app_confirm_dialog.dart';
 import 'package:stockapp/widgets/emotion_diary/DairyBubble.dart';
 import 'package:stockapp/widgets/emotion_diary/EmotionAnalysisCard.dart';
 import 'package:stockapp/widgets/emotion_diary/EmotionHeader.dart';
@@ -77,6 +78,23 @@ class _DiaryScreenState extends State<DiaryScreen> {
     return grouped;
   }
 
+  void _confirmDelete(int diaryId) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (context) => AppConfirmDialog(
+        title: '일기 삭제',
+        content: '정말 이 감정일기를 삭제하시겠습니까?',
+        cancelText: '취소',
+        confirmText: '삭제',
+      ),
+    );
+
+    if (shouldDelete == true) {
+      await _api.deleteDiary(diaryId);
+      _loadDiaries(); // 목록 새로고침
+    }
+  }
+
   List<Widget> _buildGroupedDiaryWidgets() {
     final grouped = groupDiariesByDate(_diaryList);
     final sortedDateKeys = grouped.keys.toList()..sort((a, b) => a.compareTo(b));
@@ -101,7 +119,7 @@ class _DiaryScreenState extends State<DiaryScreen> {
       for (final diary in grouped[dateKey]!) {
         widgets.addAll([
           const SizedBox(height: 6),
-          DiaryBubble(text: diary['content'] ?? ''),
+          DiaryBubble(text: diary['content'] ?? '', onDelete: () => _confirmDelete(diary['diaryId'])),
           const SizedBox(height: 8),
           EmotionAnalysisCard(
             emotions: List<String>.from(diary['emotion'] ?? []),

--- a/lib/widgets/emotion_diary/DairyBubble.dart
+++ b/lib/widgets/emotion_diary/DairyBubble.dart
@@ -2,27 +2,57 @@ import 'package:flutter/material.dart';
 
 class DiaryBubble extends StatelessWidget {
   final String text;
+  final VoidCallback? onDelete;
 
-  const DiaryBubble({super.key, required this.text});
+  const DiaryBubble({super.key, required this.text, this.onDelete});
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.centerRight,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 224),
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: Colors.black,
-            borderRadius: BorderRadius.circular(8),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end, // 말풍선 우측 정렬
+      crossAxisAlignment: CrossAxisAlignment.end, // 아래 기준 정렬
+      children: [
+        // 삭제 아이콘 (말풍선 왼쪽 아래)
+        if (onDelete != null)
+          Row(
+            children: [
+              // 삭제 아이콘
+              IconButton(
+                icon: const Icon(
+                  Icons.delete,
+                  size: 17,
+                  color: Color(0xFFB3B3B3),
+                ),
+                onPressed: onDelete,
+                padding: EdgeInsets.zero,
+                visualDensity: VisualDensity(horizontal: -3, vertical: -3),
+                constraints: const BoxConstraints(maxWidth: 8),
+                //splashRadius: 2,
+                tooltip: '삭제',
+              ),
+            ],
           ),
-          child: Text(
-            text,
-            style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 12, color: Colors.white),
+
+        // 말풍선
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 224),
+          child: Container(
+            padding: const EdgeInsets.all(15),
+            decoration: BoxDecoration(
+              color: Colors.black,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontWeight: FontWeight.w500,
+                fontSize: 12,
+                color: Colors.white,
+              ),
+            ),
           ),
         ),
-      ),
+      ],
     );
   }
 }

--- a/lib/widgets/emotion_diary/EmotionAnalysisCard.dart
+++ b/lib/widgets/emotion_diary/EmotionAnalysisCard.dart
@@ -19,7 +19,7 @@ class EmotionAnalysisCard extends StatelessWidget {
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 224),
         child: Container(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(15),
           decoration: BoxDecoration(
             border: Border.all(color: Colors.black),
             borderRadius: BorderRadius.circular(8),
@@ -30,11 +30,12 @@ class EmotionAnalysisCard extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  const Icon(Icons.sentiment_satisfied_alt, color: Colors.orange),
-                  const SizedBox(width: 8),
+                  const Icon(Icons.sentiment_satisfied_alt, color: Colors.orange,size: 16,),
+                  const SizedBox(width: 7),
                   Expanded(
                     child: Text(
                       '감정 분석: ${emotions.join(", ")}',
+                      style: TextStyles.contentText,
                       softWrap: true,
                       overflow: TextOverflow.visible,
                     ),
@@ -42,13 +43,21 @@ class EmotionAnalysisCard extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 10),
-              Text('💡 투자 조언: $feedback'),
+              Text('💡 투자 조언: $feedback', style: TextStyles.contentText),
               const SizedBox(height: 10),
-              Text('📝 오늘의 일기: $summary'),
+              Text('📝 오늘의 일기: $summary', style: TextStyles.contentText),
             ],
           ),
           ),
         ),
       );
   }
+}
+
+class TextStyles {
+  static const TextStyle contentText = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 13,
+  );
+
 }

--- a/lib/widgets/emotion_diary/EmotionHeader.dart
+++ b/lib/widgets/emotion_diary/EmotionHeader.dart
@@ -8,14 +8,13 @@ class EmotionHeader extends StatelessWidget {
     return Column(
       children: const [
         SizedBox(height: 10),
-        Text('ai 감정 투자 일기', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+        Text('AI 감정 투자 일기', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
         SizedBox(height: 4),
         Text(
           '입력한 투자 일기를 AI가 감정 분석하여\n감정 상태와 투자 조언을 제공해드립니다.',
           textAlign: TextAlign.center,
           style: TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
         ),
-        SizedBox(height: 6,),
       ],
     );
   }

--- a/lib/widgets/emotion_diary/EmotionInputBar.dart
+++ b/lib/widgets/emotion_diary/EmotionInputBar.dart
@@ -37,13 +37,16 @@ class _EmotionInputBarState extends State<EmotionInputBar> {
       child: TextField(
         controller: _controller,
         onSubmitted: (_) => _handleSend(),
+        style: TextStyle(fontWeight: FontWeight.w500, fontSize: 13),
         decoration: InputDecoration(
           hintText: '오늘 투자하며 느낀 감정을 자유롭게 적어보세요.',
+          hintStyle: TextStyle(color: Color(0xFF8D8D8D)),
           filled: true,
           fillColor: const Color(0xFFF2F2F2),
           contentPadding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
           suffixIcon: IconButton(
             icon: const Icon(Icons.send),
+            color: Colors.black,
             onPressed: _handleSend,
           ),
           border: OutlineInputBorder(


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
투자 일기 삭제 기능 추가

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39 

## ⏳ 작업 내용
- 투자 일기 삭제 연동
- 디자인 수정

## 📸 스크린샷
<img width="414" height="894" alt="image" src="https://github.com/user-attachments/assets/f62d1813-9157-4e32-9419-49df6551b7ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 감정 일기 항목을 삭제할 수 있는 기능을 추가하고, 삭제 전 확인 대화상자를 제공했습니다.
  * 일기 버블에 삭제 버튼을 지원하도록 개선했습니다.

* 스타일
  * 헤더 문구 표기를 “AI 감정 투자 일기”로 정리했습니다.
  * 입력창 텍스트/힌트 스타일과 아이콘 색상을 다듬었습니다.
  * 분석 카드의 텍스트 스타일을 통일하고 패딩·아이콘 크기·간격을 조정했습니다.
  * 일기 버블 레이아웃을 개선해 삭제 버튼 배치를 최적화하고 텍스트 가독성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->