### PR TITLE
[FEAT] 관심 종목 리스트 + 설정 페이지

### DIFF
--- a/lib/data/interestlist_api.dart
+++ b/lib/data/interestlist_api.dart
@@ -1,4 +1,3 @@
-// lib/data/watchlist_api.dart
 import 'package:dio/dio.dart';
 import '../models/stock_brief.dart';
 import 'package:stockapp/services/api_client.dart';

--- a/lib/screens/interest/interest_screen.dart
+++ b/lib/screens/interest/interest_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/data/watchlist_api.dart';
 import 'package:stockapp/models/StockItemModel.dart';
+import 'package:stockapp/screens/mypage_interest_screen.dart';
 import 'package:stockapp/widgets/interest/WatchlistAppBarActions.dart';
 
 class InterestScreen extends StatefulWidget {
@@ -41,7 +42,16 @@ class _InterestScreenState extends State<InterestScreen> {
         foregroundColor: Colors.black,
         centerTitle: true,
         actions: [
-          IconButton(onPressed: () {/* 설정 */}, icon: const Icon(Icons.settings)),
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const WatchlistEditPage(),
+                ),
+              );
+            },
+            icon: const Icon(Icons.settings),
+          ),
           IconButton(onPressed: () {/* 추가 */}, icon: const Icon(Icons.add)),
         ],
       ),

--- a/lib/screens/mypage_interest_screen.dart
+++ b/lib/screens/mypage_interest_screen.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/data/interestlist_api.dart';
+import 'package:stockapp/data/watchlist_api.dart';
+import 'package:stockapp/models/stock_brief.dart';
+import 'package:stockapp/widgets/mypage/interest/empty_state.dart';
+import 'package:stockapp/widgets/mypage/interest/stock_tile.dart';
+
+class WatchlistEditPage extends StatefulWidget {
+  const WatchlistEditPage({super.key});
+
+  @override
+  State<WatchlistEditPage> createState() => _WatchlistEditPageState();
+}
+
+class _WatchlistEditPageState extends State<WatchlistEditPage> {
+  bool _editMode = false;
+  final Set<int> _selected = {}; // id는 int이므로 Set<int>
+  final InterestlistApi _apiService = InterestlistApi();
+  final WatchlistApiService _apiService2 = WatchlistApiService();
+
+  List<StockBrief> _items = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadItems();
+  }
+
+  Future<void> _loadItems() async {
+    try {
+      final result = await _apiService.fetchWatchlist();
+      setState(() {
+        _items = result;
+        _loading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _loading = false;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('관심종목 불러오기 실패: $e')),
+      );
+    }
+  }
+
+  void _toggleEdit() {
+    setState(() {
+      _editMode = !_editMode;
+      _selected.clear();
+    });
+  }
+
+  void _deleteSelected() async {
+    final idsToDelete = _selected.toList();
+
+    try {
+      // 1. 서버에 삭제 요청
+      for (final id in idsToDelete) {
+        await _apiService2.removeFromWatchlist(id.toString());
+        // StockItem.id 가 String이면 그대로, int면 toString() 필요
+      }
+
+      // 2. 로컬 리스트 갱신
+      setState(() {
+        _items.removeWhere((e) => _selected.contains(e.id));
+        _selected.clear();
+        if (_items.isEmpty) _editMode = false;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('✅ ${idsToDelete.length}개 종목 삭제됨')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('❌ 삭제 실패: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFFFFF),
+      appBar: AppBar(
+        elevation: 0,
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new_rounded),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        title: const Text(
+          '관심 종목 편집',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+        ),
+        actions: [
+          TextButton(
+            onPressed: _items.isEmpty ? null : _toggleEdit,
+            child: Text(
+              _editMode ? '완료' : '편집',
+              style: TextStyle(
+                color: _items.isEmpty
+                    ? theme.disabledColor
+                    : Color(0xFF797979),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // 서브헤더
+          Container(
+            color: Colors.white,
+            padding: const EdgeInsets.fromLTRB(16, 5, 16, 5),
+            child:Row(
+              children: [
+                if (_editMode) ...[
+                  Checkbox(
+                    value: _selected.length == _items.length && _items.isNotEmpty,
+                    activeColor: Colors.black, // ✅ 체크박스 배경(체크됐을 때) 색상
+                    checkColor: Colors.white,  // ✅ 체크 표시(✓) 색상
+                    onChanged: (checked) {
+                      setState(() {
+                        if (checked == true) {
+                          _selected.clear();
+                          _selected.addAll(_items.map((e) => e.id));
+                        } else {
+                          _selected.clear();
+                        }
+                      });
+                    },
+                  ),
+                  const Text(
+                    '전체',
+                    style: TextStyle(fontSize: 17, fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(width: 12),
+                ] else ...[
+                  Text(
+                    '관심 ${_items.length}개',
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF797979),
+                    ),
+                  ),
+                ],
+
+                const Spacer(),
+
+                if (_editMode)
+                  TextButton(
+                    child: Text('삭제 (${_selected.length})'),
+                    onPressed: _selected.isEmpty ? null : _deleteSelected,
+                  ),
+              ],
+            ),
+          ),
+          // 리스트
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : _items.isEmpty
+                ? const EmptyState()
+                : _editMode
+                ? _buildReorderableList()
+                : _buildNormalList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNormalList() {
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: _items.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 4),
+      itemBuilder: (context, index) {
+        final item = _items[index];
+        return StockTile(
+          item: item,
+          onTap: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('${item.name} 상세로 이동')),
+            );
+          },
+          trailing: const Icon(Icons.chevron_right_rounded, color: Colors.grey),
+        );
+      },
+    );
+  }
+
+  Widget _buildReorderableList() {
+    return ReorderableListView.builder(
+      buildDefaultDragHandles: false,
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      itemCount: _items.length,
+      itemBuilder: (context, index) {
+        final item = _items[index];
+        final selected = _selected.contains(item.id);
+
+        return Dismissible(
+          key: ValueKey(item.id),
+          background: Container(
+            color: Colors.redAccent,
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: const Icon(Icons.delete, color: Colors.black),
+          ),
+          direction: DismissDirection.endToStart,
+          onDismissed: (_) {
+            setState(() => _items.removeAt(index));
+          },
+          child: ReorderableDragStartListener(
+            index: index,
+            child: StockTile(
+              item: item,
+              leading: Checkbox(
+                value: selected,
+                activeColor: Colors.black,
+                checkColor: Colors.white,
+                onChanged: (v) {
+                  setState(() {
+                    if (v == true) {
+                      _selected.add(item.id);
+                    } else {
+                      _selected.remove(item.id);
+                    }
+                  });
+                },
+              ),
+              trailing: const Icon(Icons.drag_indicator_rounded,
+                  color: Colors.grey),
+              onTap: () {
+                setState(() {
+                  if (selected) {
+                    _selected.remove(item.id);
+                  } else {
+                    _selected.add(item.id);
+                  }
+                });
+              },
+            ),
+          ),
+        );
+      },
+      onReorder: (oldIndex, newIndex) {
+        setState(() {
+          if (newIndex > oldIndex) newIndex -= 1;
+          final moved = _items.removeAt(oldIndex);
+          _items.insert(newIndex, moved);
+        });
+        // TODO: 서버 순서 업데이트 API 연동
+      },
+    );
+  }
+}

--- a/lib/widgets/interest/WatchlistAppBarActions.dart
+++ b/lib/widgets/interest/WatchlistAppBarActions.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/data/interestlist_api.dart';
 import 'package:stockapp/data/recent_api.dart';
+import 'package:stockapp/data/stock_detail_api.dart';
+import 'package:stockapp/models/StockItemModel.dart';
 import 'package:stockapp/models/stock.dart';
 import '../../models/stock_brief.dart';
 import '../../widgets/common/TopTabSelector.dart';
@@ -76,39 +78,53 @@ class _WatchlistViewState extends State<WatchlistView> {
   }
 }
 
-class _WatchlistListFuture extends StatelessWidget {
+class _WatchlistListFuture extends StatefulWidget {
   final Future<List<StockBrief>> future;
   final Future<void> Function() onRefresh;
   const _WatchlistListFuture({required this.future, required this.onRefresh});
 
   @override
+  State<_WatchlistListFuture> createState() => _WatchlistListFutureState();
+}
+
+class _WatchlistListFutureState extends State<_WatchlistListFuture> {
+  final _detailApi = StockDetailApiService();
+  final Map<int, Future<StockItem?>> _cache = {}; // ✅ 캐시
+
+  @override
   Widget build(BuildContext context) {
     return FutureBuilder<List<StockBrief>>(
-      future: future,
+      future: widget.future,
       builder: (context, snap) {
-        if (snap.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
-        }
-        if (snap.hasError) {
-          return Center(
-            child: TextButton.icon(
-              onPressed: onRefresh,
-              icon: const Icon(Icons.refresh),
-              label: Text('불러오기 실패: ${snap.error}'),
-            ),
-          );
-        }
-        final items = snap.data ?? const <StockBrief>[];
+        if (!snap.hasData) return const Center(child: CircularProgressIndicator());
+        final items = snap.data!;
+
         return RefreshIndicator(
-          onRefresh: onRefresh,
+          onRefresh: widget.onRefresh,
           child: ListView.builder(
-            physics: const AlwaysScrollableScrollPhysics(),
             itemCount: items.length,
             itemBuilder: (context, i) {
               final s = items[i];
-              return WatchlistItem(
-                stock: Stock(id: s.id, name: s.name, imageUrl: s.imageUrl),
-                onTap: () {},
+              _cache[s.id] ??= _detailApi.fetchStockDetail(s.id.toString()).then((resp) {
+                return StockItem(
+                  stockId: s.id,
+                  name: s.name,
+                  price: int.tryParse((resp.price ?? '').replaceAll(',', '')) ?? 0,
+                  changeRate: double.tryParse((resp.changeRate ?? '').replaceAll('%', '')) ?? 0.0,
+                  imageUrl: s.imageUrl,
+                  rank: 0,
+                );
+              });
+
+              return FutureBuilder<StockItem?>(
+                future: _cache[s.id], // ✅ 캐싱된 Future 사용
+                builder: (context, qSnap) {
+                  final quote = qSnap.data;
+                  return WatchlistItem(
+                    stock: Stock(id: s.id, name: s.name, imageUrl: s.imageUrl),
+                    quote: quote,
+                  );
+                },
               );
             },
           ),

--- a/lib/widgets/interest/WatchlistItem.dart
+++ b/lib/widgets/interest/WatchlistItem.dart
@@ -1,10 +1,9 @@
-// screens/watchlist/widgets/watchlist_item.dart
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/stock.dart';
 import 'package:stockapp/models/StockItemModel.dart';        // 시세 모델
 import 'package:stockapp/screens/interest/interest_pattern_screen.dart';
 import 'package:stockapp/widgets/common/app_button.dart';
-import 'package:stockapp/widgets/main/StockItems.dart' as Tile; // 재사용 타일
+import 'package:stockapp/widgets/main/StockItems.dart'; // 재사용 타일
 
 class WatchlistItem extends StatelessWidget {
   /// 기본 종목 정보 (id, name, image)
@@ -34,7 +33,7 @@ class WatchlistItem extends StatelessWidget {
       imageUrl: stock.imageUrl,
     );
 
-    return Tile.StockItems(
+    return StockItems(
       stock: merged,
       onTap: onTap,
       // 관심종목 전용 오른쪽 액션들
@@ -56,17 +55,10 @@ class WatchlistItem extends StatelessWidget {
               );
             },
           ),
-          // 필요 시 알림 버튼도 여기서 추가 가능
-          // const SizedBox(width: 6),
-          // IconButton(
-          //   onPressed: () {/* 알림 토글 */},
-          //   icon: const Icon(Icons.notifications_none),
-          //   splashRadius: 20,
-          // ),
         ],
       ),
       // 화면에 맞게 여백 살짝
-      padding: const EdgeInsets.symmetric(vertical: 10),
+      padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
     );
   }
 }

--- a/lib/widgets/main/StockItems.dart
+++ b/lib/widgets/main/StockItems.dart
@@ -1,4 +1,3 @@
-// lib/widgets/main/StockItems.dart
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:stockapp/models/StockItemModel.dart';

--- a/lib/widgets/mypage/interest/empty_state.dart
+++ b/lib/widgets/mypage/interest/empty_state.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class EmptyState extends StatelessWidget {
+  final String message;
+  const EmptyState({super.key, this.message = '관심 종목이 없습니다.'});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        message,
+        textAlign: TextAlign.center,
+        style: TextStyle(color: Colors.grey[600]),
+      ),
+    );
+  }
+}

--- a/lib/widgets/mypage/interest/stock_tile.dart
+++ b/lib/widgets/mypage/interest/stock_tile.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:stockapp/models/stock_brief.dart';
+
+class StockTile extends StatelessWidget {
+  final StockBrief item;
+  final Widget? leading;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  const StockTile({
+    super.key,
+    required this.item,
+    this.leading,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              if (leading != null) leading!,
+              if (leading != null) const SizedBox(width: 8),
+
+              /// 종목 이미지
+              CircleAvatar(
+                radius: 20,
+                backgroundColor: const Color(0xFFF0F2F5),
+                backgroundImage:
+                item.imageUrl != null ? NetworkImage(item.imageUrl!) : null,
+                child: item.imageUrl == null
+                    ? Text(
+                  item.name.isNotEmpty
+                      ? item.name.characters.first
+                      : '?',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                    color: Colors.black54,
+                  ),
+                )
+                    : null,
+              ),
+
+              const SizedBox(width: 12),
+
+              /// 종목명
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(item.name,
+                        style: const TextStyle(
+                            fontSize: 15, fontWeight: FontWeight.w600)),
+                    const SizedBox(height: 2),
+                  ],
+                ),
+              ),
+
+              if (trailing != null) trailing!,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
관심 종목 리스트 + 설정 페이지

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39 

## ⏳ 작업 내용
- 관심 종목 리스트 정보 띄우기
- 관심 종목 설정 페이지 구현

## 📸 스크린샷

https://github.com/user-attachments/assets/44d26037-7697-4919-9bb5-a774d2fd73d6




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 관심종목 설정 아이콘에서 편집 화면으로 이동 가능
  - 관심종목 편집 화면 추가: 다중 선택/전체 선택, 삭제, 드래그로 순서 변경, 스와이프 삭제 지원
- 개선
  - 빈 상태 메시지 표시(“관심 종목이 없습니다.”)
  - 종목 타일 UI 개선: 아바타(이미지/이니셜), 리스팅 간격 조정, 일반/편집 모드 전환
  - 항목별 로딩 및 새로고침으로 상세 시세 표시가 더 매끄러워짐
- 성능
  - 시세 데이터 캐싱으로 목록 반응 속도 향상
- 안정성
  - 오류 발생 시 스낵바로 안내 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->