### PR TITLE
[Feat] 관심종목 백테스팅 결과 차트 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:stockapp/screens/login_screen.dart';
 import 'package:stockapp/routes/TabView.dart';
@@ -30,7 +31,15 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         fontFamily: 'Pretendard', //폰트 추가
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          surfaceTintColor: Colors.white,
+        ),
       ),
+
       // 토큰이 있으면 바로 Tabview로 진입하여 자동 로그인
       home: AuthState.accessToken != null
           ? const Tabview()

--- a/lib/models/pattern_apply.dart
+++ b/lib/models/pattern_apply.dart
@@ -100,4 +100,17 @@ class BacktestResult {
     maxReturn: (json['maxReturn'] as num).toDouble(),
     maxReturnDate: json['maxReturnDate'] as String,
   );
+
+  Map<String, dynamic> toJson() => {
+    'backtestId': backtestId,
+    'executedAt': executedAt,
+    'matchedCount': matchedCount,
+    'startDate': startDate,
+    'endDate': endDate,
+    'winRate': winRate,
+    'averageReturn': averageReturn,
+    'maxReturn': maxReturn,
+    'maxReturnDate': maxReturnDate,
+    // 필요한 필드 더 있으면 여기에 추가
+  };
 }

--- a/lib/screens/interest/interest_pattern_screen.dart
+++ b/lib/screens/interest/interest_pattern_screen.dart
@@ -151,13 +151,24 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
           appBar: AppBar(backgroundColor: Colors.white),
           backgroundColor: Colors.white,
           body: RefreshIndicator(
-            onRefresh: _reload,
+          onRefresh: _reload,
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 StockHeader(name: title, imageUrl: headerImg),
-                Expanded(
-                  child: hasPattern
-                      ? PatternExistsView(
+
+                const Divider(
+                  color: Color(0xFFB5B5B5), // 선 색상
+                  thickness: 1,             // 두께
+                  height: 13,               // 위아래 여백 포함
+                  indent: 16,               // 왼쪽 들여쓰기
+                  endIndent: 16,            // 오른쪽 들여쓰기
+                ),
+
+                if (hasPattern)
+                  PatternExistsView(
                     data: data!,
                     onDelete: () {
                       final id = data.patternApplyId;
@@ -169,23 +180,26 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
                       }
                       _confirmAndDelete(id);
                     },
-                    onEdit: () {final id = data.patternApplyId; // PatternApply 모델의 id
-                    if (id == null) return;
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => PatternLibraryScreen(
-                          stockId: widget.stockId,
-                          stockName: widget.stockName,
-                          patternApplyId: id, // ← 여기!
+                    onEdit: () {
+                      final id = data.patternApplyId;
+                      if (id == null) return;
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => PatternLibraryScreen(
+                            stockId: widget.stockId,
+                            stockName: widget.stockName,
+                            patternApplyId: id,
+                          ),
                         ),
-                      ),
-                    );},
+                      );
+                    },
                     onRunBacktest: _runningBacktest
                         ? null
                         : () => _onRunBacktest(data.pattern!.patternId),
                   )
-                      : PatternEmptyView(
+                else
+                  PatternEmptyView(
                     onAdd: () async {
                       final applied = await Navigator.push<bool>(
                         context,
@@ -198,17 +212,16 @@ class _InterestPatternScreenState extends State<InterestPatternScreen> {
                       );
 
                       if (applied == true) {
-                        // 즉시 '있음' 화면으로 전환 후 서버 동기화
                         setState(() => _future = Future.value(null));
                         await Future.delayed(const Duration(milliseconds: 120));
                         _reload();
                       }
                     },
                   ),
-                ),
               ],
             ),
           ),
+        ),
         );
       },
     );

--- a/lib/widgets/common/backtest_candle_chart.dart
+++ b/lib/widgets/common/backtest_candle_chart.dart
@@ -1,0 +1,183 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:interactive_chart/interactive_chart.dart';
+import 'package:stockapp/data/backtest_candle_api.dart';
+import 'package:stockapp/data/backtest_api.dart';
+
+class BacktestCandleChart extends StatefulWidget {
+  final int backtestId;
+  const BacktestCandleChart({super.key, required this.backtestId});
+
+  @override
+  State<BacktestCandleChart> createState() => _BacktestCandleChartState();
+}
+
+class _BacktestCandleChartState extends State<BacktestCandleChart> {
+  List<CandleData> _candles = [];
+  bool _loading = false;
+
+  int? _matchStart;
+  int? _matchEnd;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCandlesAndHighlight();
+  }
+
+  /// 백테스트 캔들과 하이라이트 범위 불러오기
+  Future<void> _loadCandlesAndHighlight() async {
+    setState(() => _loading = true);
+
+    try {
+      // 1️⃣ 백테스트 상세 불러오기
+      final detail = await BacktestService.fetchBacktestResult(widget.backtestId);
+      final result = detail['result'] ?? detail;
+      final hr = result['highlightRange'];
+      debugPrint('✅ highlightRange: $hr');
+
+      // 2️⃣ 캔들 데이터 불러오기
+      final candles = await fetchBacktestCandles(backtestId: widget.backtestId);
+      if (candles.isEmpty) {
+        debugPrint('⚠️ 캔들 데이터 없음');
+        setState(() {
+          _candles = [];
+          _loading = false;
+        });
+        return;
+      }
+
+      // 3️⃣ highlightRange가 존재할 경우 인덱스 계산
+      int? startIdx;
+      int? endIdx;
+
+      if (hr is Map && hr['fromDate'] != null && hr['toDate'] != null) {
+        final fromDate = DateTime.tryParse(hr['fromDate'].toString());
+        final toDate = DateTime.tryParse(hr['toDate'].toString());
+        if (fromDate != null && toDate != null) {
+          // 시간대 보정 (서버 UTC 가정)
+          final from = fromDate.toUtc();
+          final to = toDate.toUtc();
+
+          // 캔들 타임스탬프 비교
+          for (int i = 0; i < candles.length; i++) {
+            final t = DateTime.fromMillisecondsSinceEpoch(candles[i].timestamp).toUtc();
+            if (!t.isBefore(from)) {
+              startIdx = i;
+              break;
+            }
+          }
+
+          if (startIdx != null) {
+            for (int i = startIdx; i < candles.length; i++) {
+              final t = DateTime.fromMillisecondsSinceEpoch(candles[i].timestamp).toUtc();
+              if (t.isAfter(to)) {
+                endIdx = i - 1;
+                break;
+              }
+            }
+            endIdx ??= candles.length - 1;
+          }
+        }
+      }
+
+      setState(() {
+        _candles = candles;
+        _matchStart = startIdx;
+        _matchEnd = endIdx;
+        _loading = false;
+      });
+
+      debugPrint('🎯 highlight index: $_matchStart ~ $_matchEnd');
+
+    } catch (e, st) {
+      debugPrint('❌ 캔들/하이라이트 로딩 실패: $e\n$st');
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 260,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 2)],
+      ),
+      clipBehavior: Clip.none,
+      child: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _candles.isEmpty
+          ? const Center(child: Text('캔들 데이터 없음'))
+          : Stack(
+        children: [
+          InteractiveChart(
+            candles: _candles,
+            style: const ChartStyle(
+              priceGainColor: Color(0xFFDF1525),
+              priceLossColor: Color(0xFF1573FE),
+            ),
+          ),
+          // 🟨 노란색 하이라이트
+          if (_matchStart != null &&
+              _matchEnd != null &&
+              _matchEnd! >= _matchStart!)
+            Positioned.fill(
+              child: CustomPaint(
+                painter: _MatchOverlayPainter(
+                  start: _matchStart!,
+                  end: _matchEnd!,
+                  total: _candles.length,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 노란색 하이라이트 페인터
+class _MatchOverlayPainter extends CustomPainter {
+  final int start;
+  final int end;
+  final int total;
+
+  _MatchOverlayPainter({
+    required this.start,
+    required this.end,
+    required this.total,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (total <= 0 || end < start) return;
+
+    final candleWidth = size.width / total;
+    final rect = Rect.fromLTWH(
+      start * candleWidth,
+      0,
+      (end - start + 1) * candleWidth,
+      size.height,
+    );
+
+    // 🟨 노란색 배경
+    final fill = Paint()
+      ..color = Colors.amber.withValues(alpha: 0.2)
+      ..style = PaintingStyle.fill;
+    canvas.drawRect(rect, fill);
+
+    // 🟨 노란색 테두리
+    final border = Paint()
+      ..color = Colors.amber
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    canvas.drawRect(rect, border);
+  }
+
+  @override
+  bool shouldRepaint(covariant _MatchOverlayPainter old) {
+    return start != old.start || end != old.end || total != old.total;
+  }
+}

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
-import 'package:stockapp/screens/backtest/backtest_result_screen.dart';
 import 'package:stockapp/widgets/common/InfoCardGroup.dart';
+import 'package:stockapp/screens/backtest/backtest_result_screen.dart';
+import 'package:stockapp/widgets/common/backtest_candle_chart.dart';
 import 'dart:math' as math;
-import 'package:stockapp/widgets/common/app_button.dart';
 
 class BacktestResultCard extends StatelessWidget {
   final BacktestResult result;
-  const BacktestResultCard({required this.result});
+  const BacktestResultCard({super.key, required this.result});
 
   double _truncate(num v, int decimals) {
     final f = math.pow(10, decimals).toDouble();
@@ -18,7 +18,7 @@ class BacktestResultCard extends StatelessWidget {
       num v, {
         bool inputIsRatio = false, // true면 0.053 -> 5.3%
         int decimals = 2,
-        bool round = true,    // false면 반올림 안 하고 자리수에서 자름(내림/절삭)
+        bool round = true,
       }) {
     final p = (inputIsRatio ? v * 100 : v.toDouble());
     final d = round ? double.parse(p.toStringAsFixed(decimals))
@@ -29,91 +29,80 @@ class BacktestResultCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 2),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+
+          // 실행일, 매칭 횟수
+          Row(
             children: [
-              // 실행일, 매칭 횟수
-              Row(
-                children: [
-                  Text('실행 날짜 : ',
-                      style: TextStyles.partName),
-                  Text('${result.executedAt}', style: TextStyles.valueText,),
-                  SizedBox(width: 10),
-                  Text('매칭 횟수 : ', style: TextStyles.partName),
-                  Text('${result.matchedCount}', style: TextStyles.valueText,),
-                ],
-
-              ),
-              const SizedBox(height: 12),
-              //패턴
-
-
-              //기간
-              Row(
-                children: [
-                  Text('기간 : ', style: TextStyles.partName,),
-                  Text('${result.startDate} ~ ${result.endDate}', style: TextStyles.valueText,),
-                  const Spacer(),
-                  TextButton(
-                    onPressed: () {
-                      // Navigator.of(context).push(
-                      //   MaterialPageRoute(
-                      //     builder: (_) => BacktestResultScreen(
-                      //       patternId: patt.patternId,
-                      //       stockId: data.stockId,
-                      //       stockName: data.stockName, // 앱바 타이틀용
-                      //     ),
-                      //   ),
-                      // );
-                    },
-                    style: TextButton.styleFrom(
-                      minimumSize: Size.zero,
-                      padding: EdgeInsets.zero,
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                      child: Text('더보기',
-                        style: TextStyle(color: Color(0xFF9D9D9D), fontSize: 13),
-                      ),
-                  ),
-                ],
-              ),
-
-              // 지표들
-              InfoCardGroup(
-                rows: [
-                  {'label': '승률', 'value': _fmtPct(result.winRate, decimals: 1)},
-                  {'label': '평균 수익', 'value': _fmtPct(result.averageReturn, decimals: 2, inputIsRatio: false), 'color': const Color(0xFF1573FE)},
-                  {'label': '최대 수익', 'value': _fmtPct(result.maxReturn,   decimals: 2, round: false), 'subValue': result.maxReturnDate,'color': const Color(0xFF1573FE)},
-                ],),
-
+              Text('실행 날짜 : ', style: TextStyles.partName),
+              Text('${result.executedAt}', style: TextStyles.valueText),
+              const SizedBox(width: 10),
+              Text('매칭 횟수 : ', style: TextStyles.partName),
+              Text('${result.matchedCount}', style: TextStyles.valueText),
             ],
-          )
-    );
+          ),
+          const SizedBox(height: 12),
 
-  }
-}
+          // 백테스팅 캔들차트
+          BacktestCandleChart(backtestId: result.backtestId),
 
-class _Metric extends StatelessWidget {
-  final String label;
-  final String value;
-  const _Metric({required this.label, required this.value});
+          const SizedBox(height: 16),
 
-  @override
-  Widget build(BuildContext context) {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.only(right: 10, bottom: 6),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(label,
-                style: TextStyle(fontSize: 12, color: Colors.grey.shade600)),
-            const SizedBox(height: 4),
-            Text(value,
-                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
-          ],
-        ),
+          // 기간 + 더보기 버튼
+          Row(
+            children: [
+              Text('기간 : ', style: TextStyles.partName),
+              Text(
+                '${result.startDate} ~ ${result.endDate}',
+                style: TextStyles.valueText,
+              ),
+              const Spacer(),
+              TextButton(
+                onPressed: () {
+                  // Navigator.of(context).push(
+                  //   MaterialPageRoute(
+                  //     builder: (_) => BacktestResultScreen(
+                  //       result: result, // 혹은 모델 -> Map 변환
+                  //     ),
+                  //   ),
+                  // );
+                },
+                style: TextButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: const Text(
+                  '더보기',
+                  style: TextStyle(color: Color(0xFF9D9D9D), fontSize: 13),
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 8),
+
+          // 지표
+          InfoCardGroup(
+            rows: [
+              {'label': '승률', 'value': _fmtPct(result.winRate, decimals: 1)},
+              {
+                'label': '평균 수익',
+                'value': _fmtPct(result.averageReturn, decimals: 2),
+                'color': const Color(0xFF1573FE)
+              },
+              {
+                'label': '최대 수익',
+                'value': _fmtPct(result.maxReturn, decimals: 2, round: false),
+                'subValue': result.maxReturnDate,
+                'color': const Color(0xFF1573FE)
+              },
+            ],
+          ),
+        ],
       ),
     );
   }
@@ -121,11 +110,11 @@ class _Metric extends StatelessWidget {
 
 class TextStyles {
   static const TextStyle partName = TextStyle(
-      color: Color(0xFF8198A5),
-      fontSize: 14
+    color: Color(0xFF8198A5),
+    fontSize: 14,
   );
-  static const TextStyle valueText= TextStyle(
-      fontWeight: FontWeight.w500,
-      fontSize: 13
+  static const TextStyle valueText = TextStyle(
+    fontWeight: FontWeight.w500,
+    fontSize: 13,
   );
 }

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -62,13 +62,14 @@ class BacktestResultCard extends StatelessWidget {
               const Spacer(),
               TextButton(
                 onPressed: () {
-                  // Navigator.of(context).push(
-                  //   MaterialPageRoute(
-                  //     builder: (_) => BacktestResultScreen(
-                  //       result: result, // 혹은 모델 -> Map 변환
-                  //     ),
-                  //   ),
-                  // );
+                  // ✅ 백테스트 상세 페이지로 이동
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => BacktestResultScreen(
+                        result: result.toJson(), // ← Map으로 변환해서 전달
+                      ),
+                    ),
+                  );
                 },
                 style: TextButton.styleFrom(
                   minimumSize: Size.zero,

--- a/lib/widgets/interest/BacktestResultCard.dart
+++ b/lib/widgets/interest/BacktestResultCard.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 class BacktestResultCard extends StatelessWidget {
   final BacktestResult result;
+
   const BacktestResultCard({super.key, required this.result});
 
   double _truncate(num v, int decimals) {
@@ -15,44 +16,52 @@ class BacktestResultCard extends StatelessWidget {
   }
 
   String _fmtPct(
-      num v, {
-        bool inputIsRatio = false, // true면 0.053 -> 5.3%
-        int decimals = 2,
-        bool round = true,
-      }) {
+    num v, {
+    bool inputIsRatio = false, // true면 0.053 -> 5.3%
+    int decimals = 2,
+    bool round = true,
+  }) {
     final p = (inputIsRatio ? v * 100 : v.toDouble());
-    final d = round ? double.parse(p.toStringAsFixed(decimals))
-        : _truncate(p, decimals);
+    final d =
+        round
+            ? double.parse(p.toStringAsFixed(decimals))
+            : _truncate(p, decimals);
     return '${d.toStringAsFixed(decimals)}%';
   }
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-
-          // 실행일, 매칭 횟수
-          Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          child: Column(
             children: [
-              Text('실행 날짜 : ', style: TextStyles.partName),
-              Text('${result.executedAt}', style: TextStyles.valueText),
-              const SizedBox(width: 10),
-              Text('매칭 횟수 : ', style: TextStyles.partName),
-              Text('${result.matchedCount}', style: TextStyles.valueText),
+              // 실행일, 매칭 횟수
+              Row(
+                children: [
+                  Text('실행 날짜 : ', style: TextStyles.partName),
+                  Text('${result.executedAt}', style: TextStyles.valueText),
+                  const SizedBox(width: 10),
+                  Text('매칭 횟수 : ', style: TextStyles.partName),
+                  Text('${result.matchedCount}', style: TextStyles.valueText),
+                ],
+              ),
+              const SizedBox(height: 12),
+
+              // 백테스팅 캔들차트
+              BacktestCandleChart(backtestId: result.backtestId),
             ],
           ),
-          const SizedBox(height: 12),
+        ),
 
-          // 백테스팅 캔들차트
-          BacktestCandleChart(backtestId: result.backtestId),
+        const SizedBox(height: 16),
 
-          const SizedBox(height: 16),
-
-          // 기간 + 더보기 버튼
-          Row(
+        // 기간 + 더보기 버튼
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 30),
+          child: Row(
             children: [
               Text('기간 : ', style: TextStyles.partName),
               Text(
@@ -62,12 +71,13 @@ class BacktestResultCard extends StatelessWidget {
               const Spacer(),
               TextButton(
                 onPressed: () {
-                  // ✅ 백테스트 상세 페이지로 이동
+                  // 백테스트 상세 페이지로 이동
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (_) => BacktestResultScreen(
-                        result: result.toJson(), // ← Map으로 변환해서 전달
-                      ),
+                      builder:
+                          (_) => BacktestResultScreen(
+                            result: result.toJson(), // ← Map으로 변환해서 전달
+                          ),
                     ),
                   );
                 },
@@ -83,28 +93,28 @@ class BacktestResultCard extends StatelessWidget {
               ),
             ],
           ),
-
-          const SizedBox(height: 8),
-
-          // 지표
-          InfoCardGroup(
+        ),
+        // 지표
+        Transform.translate(
+          offset: const Offset(0, -6),
+          child: InfoCardGroup(
             rows: [
               {'label': '승률', 'value': _fmtPct(result.winRate, decimals: 1)},
               {
                 'label': '평균 수익',
                 'value': _fmtPct(result.averageReturn, decimals: 2),
-                'color': const Color(0xFF1573FE)
+                'color': const Color(0xFF1573FE),
               },
               {
                 'label': '최대 수익',
                 'value': _fmtPct(result.maxReturn, decimals: 2, round: false),
                 'subValue': result.maxReturnDate,
-                'color': const Color(0xFF1573FE)
+                'color': const Color(0xFF1573FE),
               },
             ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:stockapp/models/pattern_apply.dart';
 import 'package:stockapp/widgets/common/app_button.dart';
+import 'package:stockapp/widgets/common/backtest_candle_chart.dart';
 import 'package:stockapp/widgets/common/pattern_line_chart.dart';
 import 'package:stockapp/widgets/interest/BacktestResultCard.dart';
 import 'package:stockapp/widgets/interest/pattern_alert_button.dart';
@@ -95,17 +96,17 @@ class PatternExistsView extends StatelessWidget {
         ),
         if (data.hasBacktest)
           Column(
-            children: [
-              BacktestResultCard(result: data.backtest!),
-              SizedBox(height: 12),
-              Align(
-                alignment: Alignment.centerRight,
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
-                ),
-              )
-            ]
+              children: [
+                BacktestResultCard(result: data.backtest!),
+                SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
+                  ),
+                )
+              ]
           )
         else
           Padding(

--- a/lib/widgets/interest/pattern_exists_view.dart
+++ b/lib/widgets/interest/pattern_exists_view.dart
@@ -26,9 +26,8 @@ class PatternExistsView extends StatelessWidget {
   Widget build(BuildContext context) {
     final patt = data.pattern!;
 
-    return ListView(
-      physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.symmetric(vertical: 8),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // 헤더 + 알림 버튼 행
         Padding(
@@ -41,7 +40,7 @@ class PatternExistsView extends StatelessWidget {
               if (data.patternApplyId != null)
                 PatternAlertButton(
                   patternApplyId: data.patternApplyId!,
-                  initialEnabled: data.isAlertEnabled ?? false, // 모델에 없으면 false
+                  initialEnabled: data.isAlertEnabled ?? false,
                 )
               else
                 IconButton(
@@ -61,11 +60,11 @@ class PatternExistsView extends StatelessWidget {
               color: Color(0xFFF4F4F4),
               borderRadius: BorderRadius.circular(8),
             ),
-              padding: const EdgeInsets.all(12),
-              child: Container(
-                color: Colors.white,
-                  child: PatternLineChart(points: patt.points)
-              )
+            padding: const EdgeInsets.all(12),
+            child: Container(
+              color: Colors.white,
+              child: PatternLineChart(points: patt.points),
+            ),
           ),
         ),
         const SizedBox(height: 12),
@@ -80,40 +79,39 @@ class PatternExistsView extends StatelessWidget {
             onEdit: onEdit,
           ),
         ),
-        SizedBox(height: 8),
-        const SizedBox(height: 13, child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: Color(0xFFEFEFEF),
+        const SizedBox(height: 8),
+        const SizedBox(
+          height: 13,
+          width: double.infinity,
+          child: DecoratedBox(
+            decoration: BoxDecoration(color: Color(0xFFEFEFEF)),
           ),
-        ),),
-        SizedBox(height: 10),
+        ),
+        const SizedBox(height: 10),
 
         // 백테스팅
-        // const PatternSectionHeader(title: '최근 백테스팅 결과'),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 15),
           child: Text('최근 백테스팅 결과', style: TextStyles.sectionHeader),
         ),
         if (data.hasBacktest)
           Column(
-              children: [
-                BacktestResultCard(result: data.backtest!),
-                SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: 8),
-                    child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
-                  ),
-                )
-              ]
+            children: [
+              BacktestResultCard(result: data.backtest!),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: AppButton(label: '다시 돌리기', onPressed: onRunBacktest),
+                ),
+              ),
+            ],
           )
         else
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: AppButton(
-                label: '백테스팅 진행하기',
-                onPressed: onRunBacktest),
+            child: AppButton(label: '백테스팅 진행하기', onPressed: onRunBacktest),
           ),
         const SizedBox(height: 24),
       ],
@@ -126,5 +124,4 @@ class TextStyles {
     fontWeight: FontWeight.w600,
     fontSize: 19,
   );
-
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
관심종목 백테스팅 결과 차트 추가

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39 

## ⏳ 작업 내용
- 관심 종목 페이지 백테스팅 결과 차트 추가
- AppBar 스크롤 시 색상 변동 제거
- '더보기' 클릭 시 백테스팅 결과 페이지 이동
- 관심 종목 페이지 UI 배치 및 간격 조정

## 📸 스크린샷
<img width="285" height="978" alt="image" src="https://github.com/user-attachments/assets/d7d17ab8-b2d3-42ea-bdcd-b276373a0e29" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 백테스트 카드에 인터랙티브 캔들 차트와 매칭 구간 하이라이트 추가
  - “더보기” 버튼으로 상세 화면 이동 지원
- UI/UX
  - 앱바를 흰 배경/검은 글자, 그림자 제거로 단정하게 개선
  - 관심 패턴 화면에 스크롤 가능 바디 적용으로 콘텐츠가 적어도 당겨서 새로고침 지원
  - 구분선, 여백, 좌측 정렬 등 레이아웃 정돈
- 버그 수정
  - 삭제 시 식별자 없음 상황에 스낵바 안내 및 안전 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->