### PR TITLE
[FEAT]감정 일기 전송 시 '분석 중' 안내 문구 추가

### DIFF
--- a/lib/screens/diary_screen.dart
+++ b/lib/screens/diary_screen.dart
@@ -63,7 +63,9 @@ class _DiaryScreenState extends State<DiaryScreen> {
     }
   }
 
-  Map<String, List<Map<String, dynamic>>> groupDiariesByDate(List<Map<String, dynamic>> diaries) {
+  Map<String, List<Map<String, dynamic>>> groupDiariesByDate(
+    List<Map<String, dynamic>> diaries,
+  ) {
     final Map<String, List<Map<String, dynamic>>> grouped = {};
 
     for (final diary in diaries) {
@@ -81,12 +83,13 @@ class _DiaryScreenState extends State<DiaryScreen> {
   void _confirmDelete(int diaryId) async {
     final shouldDelete = await showDialog<bool>(
       context: context,
-      builder: (context) => AppConfirmDialog(
-        title: '일기 삭제',
-        content: '정말 이 감정일기를 삭제하시겠습니까?',
-        cancelText: '취소',
-        confirmText: '삭제',
-      ),
+      builder:
+          (context) => AppConfirmDialog(
+            title: '일기 삭제',
+            content: '정말 이 감정일기를 삭제하시겠습니까?',
+            cancelText: '취소',
+            confirmText: '삭제',
+          ),
     );
 
     if (shouldDelete == true) {
@@ -97,7 +100,8 @@ class _DiaryScreenState extends State<DiaryScreen> {
 
   List<Widget> _buildGroupedDiaryWidgets() {
     final grouped = groupDiariesByDate(_diaryList);
-    final sortedDateKeys = grouped.keys.toList()..sort((a, b) => a.compareTo(b));
+    final sortedDateKeys =
+        grouped.keys.toList()..sort((a, b) => a.compareTo(b));
 
     final List<Widget> widgets = [];
 
@@ -119,7 +123,10 @@ class _DiaryScreenState extends State<DiaryScreen> {
       for (final diary in grouped[dateKey]!) {
         widgets.addAll([
           const SizedBox(height: 6),
-          DiaryBubble(text: diary['content'] ?? '', onDelete: () => _confirmDelete(diary['diaryId'])),
+          DiaryBubble(
+            text: diary['content'] ?? '',
+            onDelete: () => _confirmDelete(diary['diaryId']),
+          ),
           const SizedBox(height: 8),
           EmotionAnalysisCard(
             emotions: List<String>.from(diary['emotion'] ?? []),
@@ -156,7 +163,6 @@ class _DiaryScreenState extends State<DiaryScreen> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: EmotionInputBar(onSubmit: _submitDiary),
             ),
-            const SizedBox(height: 12),
           ],
         ),
       ),

--- a/lib/widgets/common/app_confirm_dialog.dart
+++ b/lib/widgets/common/app_confirm_dialog.dart
@@ -4,7 +4,7 @@ class AppConfirmDialog extends StatelessWidget {
   final String title;
   final String cancelText;
   final String confirmText;
-  final String? content; // 본문이 필요하면 사용 (선택)
+  final String? content;
 
   const AppConfirmDialog({
     super.key,
@@ -19,29 +19,65 @@ class AppConfirmDialog extends StatelessWidget {
     return AlertDialog(
       backgroundColor: Colors.white,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+
+      // 내부 여백 조정
+      titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
+      contentPadding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
+      actionsPadding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+
       title: Text(
         title,
-        style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+        style: const TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: Colors.black,
+        ),
       ),
-      content: content == null
-          ? null
-          : Text(
-        content!,
-        style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w400),
-      ),
+
+      content:
+          content == null
+              ? null
+              : Text(
+                content!,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w400,
+                  color: Colors.black,
+                  height: 1.4, // 줄간격
+                ),
+              ),
+
+      actionsAlignment: MainAxisAlignment.end, // 버튼 오른쪽 정렬
+      actionsOverflowButtonSpacing: 0,
+
+      // 버튼 영역
       actions: [
         TextButton(
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          ),
           onPressed: () => Navigator.pop(context, false),
-          child: const Text(
-            '취소',
-            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w400, color: Colors.black),
+          child: Text(
+            cancelText,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: Colors.black,
+            ),
           ),
         ),
         TextButton(
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          ),
           onPressed: () => Navigator.pop(context, true),
-          child: const Text(
-            '적용',
-            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w400, color: Colors.black),
+          child: Text(
+            confirmText,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: Colors.black,
+            ),
           ),
         ),
       ],
@@ -50,21 +86,22 @@ class AppConfirmDialog extends StatelessWidget {
 }
 
 Future<bool?> showAppConfirmDialog(
-    BuildContext context, {
-      required String title,
-      String? content,
-      String cancelText = '취소',
-      String confirmText = '적용',
-      bool barrierDismissible = true, //바깥 터치로 닫히도록
-    }) {
+  BuildContext context, {
+  required String title,
+  String? content,
+  String cancelText = '취소',
+  String confirmText = '적용',
+  bool barrierDismissible = true,
+}) {
   return showDialog<bool>(
     context: context,
     barrierDismissible: barrierDismissible,
-    builder: (_) => AppConfirmDialog(
-      title: title,
-      content: content,
-      cancelText: cancelText,
-      confirmText: confirmText,
-    ),
+    builder:
+        (_) => AppConfirmDialog(
+          title: title,
+          content: content,
+          cancelText: cancelText,
+          confirmText: confirmText,
+        ),
   );
 }

--- a/lib/widgets/emotion_diary/EmotionInputBar.dart
+++ b/lib/widgets/emotion_diary/EmotionInputBar.dart
@@ -13,47 +13,70 @@ class EmotionInputBar extends StatefulWidget {
 class _EmotionInputBarState extends State<EmotionInputBar> {
   final TextEditingController _controller = TextEditingController();
   final EmotionDiaryApi _api = EmotionDiaryApi();
+  bool _isSending = false;
 
   Future<void> _handleSend() async {
     final text = _controller.text.trim();
     if (text.isEmpty) return;
 
+    setState(() => _isSending = true);
+
     try {
       final result = await _api.postDiary(text); // 감정 분석 결과 받기
-
       widget.onSubmit(result); // 부모에게 결과 전달
 
-      print('✅ 감정 일기 전송 완료'); // 콘솔 출력
       _controller.clear();
     } catch (e) {
-      print('❌ 감정 일기 전송 실패: $e'); // 실패 로그만 출력
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('전송 실패: $e')));
+    } finally {
+      setState(() => _isSending = false);
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: TextField(
-        controller: _controller,
-        onSubmitted: (_) => _handleSend(),
-        style: TextStyle(fontWeight: FontWeight.w500, fontSize: 13),
-        decoration: InputDecoration(
-          hintText: '오늘 투자하며 느낀 감정을 자유롭게 적어보세요.',
-          hintStyle: TextStyle(color: Color(0xFF8D8D8D)),
-          filled: true,
-          fillColor: const Color(0xFFF2F2F2),
-          contentPadding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
-          suffixIcon: IconButton(
-            icon: const Icon(Icons.send),
-            color: Colors.black,
-            onPressed: _handleSend,
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 로딩 텍스트
+          if (_isSending)
+            const Padding(
+              padding: EdgeInsets.only(top: 2, bottom: 8),
+              child: Text(
+                '감정 분석 중 입니다...',
+                style: TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ),
+          // 입력창
+          TextField(
+            controller: _controller,
+            onSubmitted: (_) => _handleSend(),
+            style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 13),
+            decoration: InputDecoration(
+              hintText: '오늘 투자하며 느낀 감정을 자유롭게 적어보세요.',
+              hintStyle: const TextStyle(color: Color(0xFF8D8D8D)),
+              filled: true,
+              fillColor: const Color(0xFFF2F2F2),
+              contentPadding: const EdgeInsets.symmetric(
+                vertical: 14,
+                horizontal: 20,
+              ),
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.send),
+                color: Colors.black,
+                onPressed: _isSending ? null : _handleSend, // 전송 중이면 비활성화
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide.none,
+              ),
+            ),
           ),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(8),
-            borderSide: BorderSide.none,
-          ),
-        ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
감정 일기 전송 시 '분석 중' 안내 문구 추가

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #75

## ⏳ 작업 내용
- 감정 일기 전송 시 '분석 중' 안내 문구 추가
- AppConfirmDialog 여백 및 정렬 구조 개선

## 📸 스크린샷
https://github.com/user-attachments/assets/b41923da-fce1-41f3-af0b-25d45e0a6523




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 감정 입력바에 전송 중 표시(“감정 분석 중 입니다…”) 추가 및 전송 버튼 비활성화 처리.
  - 전송 실패 시 콘솔 로그 대신 사용자용 스낵바 오류 안내 표시.

- Style
  - 확인 대화상자(UI) 시각적 개선: 패딩, 정렬, 타이포그래피 조정 및 버튼 라벨 가독성 향상.
  - 감정 입력바 레이아웃과 패딩, 힌트 문구 정리로 입력 경험 개선.

- Refactor
  - 화면 및 위젯 전반의 코드 포맷 정리와 불필요한 간격 요소 일부 제거(동작 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->