### PR TITLE
[FEAT] 백테스팅 랭킹 타이틀 추가 #87

### DIFF
--- a/lib/screens/backtest/backtest_ranking_screen.dart
+++ b/lib/screens/backtest/backtest_ranking_screen.dart
@@ -46,8 +46,7 @@ class _BacktestRankingScreenState extends State<BacktestRankingScreen> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        backgroundColor: Colors.white,
-        title: const Text('백테스팅 랭킹'),
+        backgroundColor: Colors.white
       ),
       body: SafeArea(
         child: RefreshIndicator(
@@ -131,6 +130,32 @@ class _BacktestRankingScreenState extends State<BacktestRankingScreen> {
                 physics: const AlwaysScrollableScrollPhysics(),
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
                 children: [
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      SizedBox(height: 12),
+                      Text(
+                        '🏆 10월의 백테스팅 랭킹 🏆',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.w800,
+                          color: Colors.black,
+                        ),
+                      ),
+                      SizedBox(height: 6),
+                      Text(
+                        '(최대 수익률 기준)',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Color(0xFF9CA3AF),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      SizedBox(height: 24),
+                    ],
+                  ),
                   // 상위 1~3위 타일
                   ...topThree.map((r) => Padding(
                     padding: const EdgeInsets.only(bottom: 12),


### PR DESCRIPTION
## 🚀 개요
백테스팅 랭킹 타이틀 추가

## 📌 관련 이슈
- Closes #87

## ⏳ 작업 내용
- 백테스팅 랭킹 화면에 타이틀을 추가 했습니다.

## 📸 스크린샷
![Screenshot_20251028-191527](https://github.com/user-attachments/assets/8c5760b8-c862-495d-bdb3-dc0d5071b3ff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **스타일**
  * 백테스팅 랭킹 화면에 헤더 섹션이 추가되었습니다. 상위 랭킹 타일 위에 제목과 부제목이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->