### PR TITLE
Refactor/#89 backtest percent format fix

### DIFF
--- a/lib/screens/backtest/backtest_ranking_screen.dart
+++ b/lib/screens/backtest/backtest_ranking_screen.dart
@@ -46,8 +46,7 @@ class _BacktestRankingScreenState extends State<BacktestRankingScreen> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        backgroundColor: Colors.white,
-        title: const Text('백테스팅 랭킹'),
+        backgroundColor: Colors.white
       ),
       body: SafeArea(
         child: RefreshIndicator(
@@ -131,6 +130,32 @@ class _BacktestRankingScreenState extends State<BacktestRankingScreen> {
                 physics: const AlwaysScrollableScrollPhysics(),
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
                 children: [
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      SizedBox(height: 12),
+                      Text(
+                        '🏆 10월의 백테스팅 랭킹 🏆',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.w800,
+                          color: Colors.black,
+                        ),
+                      ),
+                      SizedBox(height: 6),
+                      Text(
+                        '(최대 수익률 기준)',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Color(0xFF9CA3AF),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      SizedBox(height: 24),
+                    ],
+                  ),
                   // 상위 1~3위 타일
                   ...topThree.map((r) => Padding(
                     padding: const EdgeInsets.only(bottom: 12),

--- a/lib/widgets/backtest/recent_backtest_result_card.dart
+++ b/lib/widgets/backtest/recent_backtest_result_card.dart
@@ -59,12 +59,10 @@ class _RecentBacktestResultCardState extends State<RecentBacktestResultCard> {
   }
 
   /// 퍼센트 값을 보기 좋게 포매팅한다.
-  /// - isRatio=true 인 경우 0.123 -> "12.30%"
-  String _formatPercent(dynamic value, {bool isRatio = false}) {
+  String _formatPercent(dynamic value) {
     if (value == null) return '0.00%';
     final numVal = (value is num) ? value : num.tryParse(value.toString()) ?? 0;
-    final p = isRatio ? (numVal * 100) : numVal;
-    return '${p.toStringAsFixed(2)}%';
+    return '${numVal.toStringAsFixed(2)}%';
   }
 
   @override
@@ -164,7 +162,7 @@ class _RecentBacktestResultCardState extends State<RecentBacktestResultCard> {
             const SizedBox(width: 13),
             Text('수익률: ', style: TextStyles.partName),
             Text(
-              '${_formatPercent(_result["averageReturn"], isRatio: true)}',
+              '${_formatPercent(_result["averageReturn"])}',
               style: TextStyles.valueText,
             ),
             const Spacer(),
@@ -180,16 +178,16 @@ class _RecentBacktestResultCardState extends State<RecentBacktestResultCard> {
           rows: [
             {
               'label': '승률',
-              'value': _formatPercent(_result['winRate'], isRatio: true),
+              'value': _formatPercent(_result['winRate']),
             },
             {
               'label': '평균 수익률',
-              'value': _formatPercent(_result['averageReturn'], isRatio: true),
+              'value': _formatPercent(_result['averageReturn']),
               'color': const Color(0xFF289BF6),
             },
             {
               'label': '최대 수익률',
-              'value': _formatPercent(_result['maxReturn'], isRatio: true),
+              'value': _formatPercent(_result['maxReturn']),
               'subValue': _result['maxReturnDate'],
               'color': const Color(0xFF289BF6),
             },


### PR DESCRIPTION
## 🚀 개요
백테스팅 퍼센트 포맷팅 연산 수정

## 📌 관련 이슈
- Closes #89 

## ⏳ 작업 내용
- 불필요한 퍼센트 포맷팅 연산 삭제

## 📸 스크린샷
![Screenshot_20251028-202856](https://github.com/user-attachments/assets/87491f06-f9f1-4e4d-b462-65848ba0b266)

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **스타일/UI**
  * 백테스팅 랭킹 화면 상단에 새로운 헤더 추가: "🏆 10월의 백테스팅 랭킹 🏆" 제목 및 부제목 표시
  * 앱바 표시 스타일 조정

* **개선**
  * 백테스팅 결과 카드의 수익률 형식 표시 로직 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->