### PR TITLE
[REFACTOR] 프로필 수정, 알림 설정 비활성화 처리 #93

### DIFF
--- a/lib/screens/mypage_screen.dart
+++ b/lib/screens/mypage_screen.dart
@@ -261,8 +261,8 @@ class _MypageScreenState extends State<MypageScreen> {
             // 메뉴 섹션 1
             _MenuTile(
               icon: Icons.person_outline,
-              title: '프로필수정',
-              onTap: () => _editProfile(context),
+              title: '프로필 수정',
+              // onTap: () => _editProfile(context),
             ),
             _divider(),
             _MenuTile(
@@ -274,7 +274,7 @@ class _MypageScreenState extends State<MypageScreen> {
             _MenuTile(
               icon: Icons.notifications_none,
               title: '알림 설정',
-              onTap: () => _goToNotificationSettings(context),
+              // onTap: () => _goToNotificationSettings(context),
             ),
             _divider(),
             _MenuTile(


### PR DESCRIPTION
## 🚀 개요
프로필 수정, 알림 설정 비활성화 처리

## 📌 관련 이슈
- Closes #93

## ⏳ 작업 내용
- 프로필수정 -> 프로필 수정
- 프로필 수정, 알림 설정 함수에 주석 처리로 비활성화 처리 

## 📸 스크린샷
<img width="381" height="807" alt="image" src="https://github.com/user-attachments/assets/508a112b-a51c-45e1-afba-8f173a79658f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 메뉴의 프로필 수정 기능이 비활성화되었습니다.
  * 메뉴의 알림 설정 기능이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->